### PR TITLE
feat(sdds-acore/theme-builder): Theme-builder colors

### DIFF
--- a/.github/workflows/android-code-quality-check.yml
+++ b/.github/workflows/android-code-quality-check.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - develop
+      - feature/*
+      - release/*
+      - hotfix/*
 
 concurrency:
   # New commit on branch cancels running workflows of the same branch

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - feature/*
 
 concurrency:
   # New commit on branch cancels running workflows of the same branch

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/ColorGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/ColorGenerator.kt
@@ -7,6 +7,7 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.XmlResourcesDocumentBuilderFactory
 import com.sdds.plugin.themebuilder.internal.token.ColorToken
 import com.sdds.plugin.themebuilder.internal.utils.FileProvider.colorsXmlFile
+import com.sdds.plugin.themebuilder.internal.utils.colorToArgbHex
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
 import java.io.File
 
@@ -68,7 +69,7 @@ internal class ColorGenerator(
         } else {
             return false
         }
-        val value = "Color(${tokenValue.origin.replace("#", "0x")})"
+        val value = "Color(${colorToArgbHex(tokenValue.origin)})"
         root.appendProperty(token.ktName, KtFileBuilder.TypeColor, value, token.description)
         return true
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientGenerator.kt
@@ -15,6 +15,7 @@ import com.sdds.plugin.themebuilder.internal.token.RadialGradientToken
 import com.sdds.plugin.themebuilder.internal.token.SweepGradientToken
 import com.sdds.plugin.themebuilder.internal.token.Token
 import com.sdds.plugin.themebuilder.internal.utils.FileProvider.gradientsXmlFile
+import com.sdds.plugin.themebuilder.internal.utils.colorToArgbHex
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
 import com.squareup.kotlinpoet.TypeSpec
 import java.io.File
@@ -240,7 +241,7 @@ internal class GradientGenerator(
         colors: List<String>,
         positions: List<Float>,
     ) {
-        val colorParams = colors.joinToString { "Color(${it.replace("#", "0x")})" }
+        val colorParams = colors.joinToString { "Color(${colorToArgbHex(it)})" }
         val positionParams = positions.joinToString { "${it}f" }
         appendProperty(
             "colors",

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyGenerator.kt
@@ -189,12 +189,17 @@ internal class TypographyGenerator(
         description: String,
         tokenValue: TypographyToken.Value,
     ) {
+        val letterSpacing = if (tokenValue.letterSpacing < 0) {
+            "(${tokenValue.letterSpacing}).sp"
+        } else {
+            "${tokenValue.letterSpacing}.sp"
+        }
         val initializer = KtFileBuilder.createConstructorCall(
             "TextStyle",
             "fontWeight = FontWeight(${tokenValue.fontWeight})",
             "fontSize = ${tokenValue.textSize}.sp",
             "lineHeight = ${tokenValue.lineHeight}.sp",
-            "letterSpacing = ${tokenValue.letterSpacing}.sp",
+            "letterSpacing = $letterSpacing",
         )
         appendProperty(name, KtFileBuilder.TypeTextStyle, initializer, description)
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/serializer/ExcludeNonAndroidPlatformTokens.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/serializer/ExcludeNonAndroidPlatformTokens.kt
@@ -38,7 +38,11 @@ private class FilteringListSerializer<E>(private val elementSerializer: KSeriali
             if (currentPlatform == null || currentPlatform != TokenPlatform.ANDROID) {
                 return@mapNotNull null
             }
-            json.decodeFromJsonElement(elementSerializer, it)
+            try {
+                json.decodeFromJsonElement(elementSerializer, it)
+            } catch (e: UnknownTypeException) {
+                null
+            }
         }
     }
 

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/serializer/Serializer.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/serializer/Serializer.kt
@@ -35,6 +35,7 @@ object Serializer {
                 subclass(RoundedShapeToken::class)
                 subclass(TypographyToken::class)
                 subclass(FontToken::class)
+                defaultDeserializer { UnknownTypeSerializer() }
             }
         }
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/serializer/UnknownTypeSerializer.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/serializer/UnknownTypeSerializer.kt
@@ -1,0 +1,24 @@
+package com.sdds.plugin.themebuilder.internal.serializer
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Сериализатор для неизвестных типов.
+ * Бросает контролируемое исключение [UnknownTypeException].
+ * @author Малышев Александр on 04.04.2024
+ */
+internal class UnknownTypeSerializer<T> : KSerializer<T> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Nothing")
+    override fun deserialize(decoder: Decoder): T = throw UnknownTypeException("unknown type")
+    override fun serialize(encoder: Encoder, value: T) = throw UnknownTypeException("unknown type")
+}
+
+/**
+ * Исключение "Неизвестный тип"
+ * @param message сообщение
+ */
+internal class UnknownTypeException(message: String) : Throwable(message)

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/token/TypographyTokens.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/token/TypographyTokens.kt
@@ -64,7 +64,7 @@ internal data class TypographyToken(
 
     /**
      * Значение токена типографии
-     * @property fontFamily семейство шрифтов
+     * @property fontFamilyRef семейство шрифтов
      * @property fontWeight вес шрифта
      * @property fontStyle стиль шрифта
      * @property textSize размер текста

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtils.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtils.kt
@@ -3,6 +3,9 @@ package com.sdds.plugin.themebuilder.internal.utils
 import java.util.Locale
 
 private val camelRegex = "(?<=[a-zA-Z])[A-Z]".toRegex()
+private const val RGBA_STR_LENGTH = 9
+private const val RGB_STR_LENGTH = 7
+private const val RGBA_ALPHA_INDEX_START = 7
 
 /**
  * Переводит строку из формата CamelCase в формат snake_case
@@ -26,4 +29,19 @@ internal fun String.techToSnakeCase(): String {
 internal fun String.withPrefixIfNeed(prefix: String? = null, delimiter: String = "_"): String {
     if (prefix.isNullOrBlank()) return this
     return "${prefix}${delimiter}$this"
+}
+
+/**
+ * Преобразует строку цвета [rgba] вида #FFFFFFFF в строку вида 0xFFFFFFFF.
+ * Также изменяет порядковый номер альфа-канала или добавляет его, если он отсутствует
+ * в исходной строке. Т.е. RGBA -> ARGB или RGB -> ARGB
+ */
+internal fun colorToArgbHex(rgba: String): String {
+    if (rgba.length == RGB_STR_LENGTH) return rgba.replace("#", "0xFF")
+    if (rgba.length != RGBA_STR_LENGTH) return rgba.replace("#", "0x")
+    return buildString {
+        append("0x")
+        append(rgba.subSequence(RGBA_ALPHA_INDEX_START, RGBA_STR_LENGTH))
+        append(rgba.subSequence(1, RGBA_ALPHA_INDEX_START))
+    }
 }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtilsKtTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtilsKtTest.kt
@@ -1,0 +1,37 @@
+package com.sdds.plugin.themebuilder.internal.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit тесты StringUtils.kt
+ * @author Малышев Александр on 12.04.2024
+ */
+class StringUtilsKtTest {
+
+    @Test
+    fun testCamelToSnakeCase() {
+        assertEquals("test_string", "TestString".camelToSnakeCase())
+        assertEquals("teststring", "Teststring".camelToSnakeCase())
+        assertEquals("test_string", "testString".camelToSnakeCase())
+    }
+
+    @Test
+    fun testTechToSnakeCase() {
+        assertEquals("test_test_string", "test.test_string".techToSnakeCase())
+        assertEquals("test_test_string", "test.test.string".techToSnakeCase())
+    }
+
+    @Test
+    fun testWithPrefixIfNeed() {
+        assertEquals("pref_test_string", "test_string".withPrefixIfNeed("pref"))
+        assertEquals("string/test_string", "test_string".withPrefixIfNeed("string", "/"))
+    }
+
+    @Test
+    fun testColorToArgbHex() {
+        assertEquals("0xFFF", colorToArgbHex("#FFF"))
+        assertEquals("0xFFABABAB", colorToArgbHex("#ABABAB"))
+        assertEquals("0xFFABABAB", colorToArgbHex("#ABABABFF"))
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/resources/color-outputs/TestColorOutputKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/color-outputs/TestColorOutputKt.txt
@@ -6,5 +6,5 @@ public object DarkColorTokens {
     /**
      * Прозрачная акцентная поверхность
      */
-    public val OnLightSurfaceTransparentAccent: Color = Color(0xFFFFFF1F)
+    public val OnLightSurfaceTransparentAccent: Color = Color(0x1FFFFFFF)
 }


### PR DESCRIPTION
What changed: 
- Default serializer was added. Compose generator color format was changed from rgba to argb;
- Dispatch conditions were extended for lint, test and build workflows.