### PR TITLE
feat(sdds-acore/theme-builder): Color palette support

### DIFF
--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/FetchPaletteTask.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/FetchPaletteTask.kt
@@ -1,0 +1,42 @@
+package com.sdds.plugin.themebuilder
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.net.URL
+
+/**
+ * Gradle-task для загрузки файла палитры
+ */
+internal abstract class FetchPaletteTask : DefaultTask() {
+
+    /**
+     * Строка URL файла палитры
+     */
+    @get:Input
+    abstract val url: Property<String>
+
+    /**
+     * Местоположение файла палитры после загрузки
+     */
+    @get:OutputFile
+    abstract val paletteFile: RegularFileProperty
+
+    /**
+     * Загружает файл с палитрой
+     */
+    @TaskAction
+    fun fetch() {
+        runCatching { URL(url.get()).readBytes() }
+            .onSuccess { themeContent ->
+                val paletteJSON = paletteFile.get().asFile
+                paletteJSON.writeBytes(themeContent)
+            }.onFailure {
+                logger.error("Can't fetch palette", it)
+                throw it
+            }
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
@@ -46,6 +46,12 @@ abstract class GenerateThemeTask : DefaultTask() {
     abstract val themeName: Property<String>
 
     /**
+     * Путь до json-файла с палитрой
+     */
+    @get:InputFile
+    abstract val paletteFile: RegularFileProperty
+
+    /**
      * Путь до json-файла с темой
      */
     @get:InputFile
@@ -158,9 +164,9 @@ abstract class GenerateThemeTask : DefaultTask() {
 
     private val themeGenerator by unsafeLazy { generatorFactory.createThemeGenerator() }
     private val colorGenerator by unsafeLazy {
-        generatorFactory.createColorGenerator(colors)
+        generatorFactory.createColorGenerator(colors, palette)
     }
-    private val gradientGenerator by unsafeLazy { generatorFactory.createGradientGenerator(gradients) }
+    private val gradientGenerator by unsafeLazy { generatorFactory.createGradientGenerator(gradients, palette) }
     private val fontGenerator by unsafeLazy { generatorFactory.createFontGenerator(fonts) }
     private val typographyGenerator by unsafeLazy {
         generatorFactory.createTypographyGenerator(typography)
@@ -234,5 +240,10 @@ abstract class GenerateThemeTask : DefaultTask() {
     private val fonts: Map<String, FontTokenValue> by unsafeLazy {
         fontFile.get().asFile.decode<Map<String, FontTokenValue>>()
             .also { logger.debug("decoded fonts $it") }
+    }
+
+    private val palette by unsafeLazy {
+        paletteFile.get().asFile.decode<Map<String, Map<String, String>>>()
+            .also { logger.debug("decoded palette $it") }
     }
 }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ThemeBuilderExtension.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ThemeBuilderExtension.kt
@@ -13,6 +13,7 @@ open class ThemeBuilderExtension {
     internal var resourcesPrefix: String? = null
     internal var parentThemeName: String = DEFAULT_PARENT_THEME_NAME
     internal var themeSource: ThemeBuilderSource? = null
+    internal var paletteUrl: String = DEFAULT_PALETTE_URL
 
     /**
      * Устанавливает источник темы по имени [name] и версии [version]
@@ -56,6 +57,13 @@ open class ThemeBuilderExtension {
         this.resourcesPrefix = prefix
     }
 
+    /**
+     * Устанавливает url для скачивания палитры
+     */
+    fun paletteUrl(url: String) {
+        this.paletteUrl = url
+    }
+
     private fun updateTarget(newTarget: ThemeBuilderTarget) {
         if (target == ThemeBuilderTarget.ALL || target == newTarget) return
         target = if (target != null) {
@@ -67,6 +75,8 @@ open class ThemeBuilderExtension {
 
     companion object {
         private const val DEFAULT_PARENT_THEME_NAME = "Sdds.Theme"
+        private const val DEFAULT_PALETTE_URL =
+            "https://raw.githubusercontent.com/salute-developers/plasma/dev/packages/plasma-colors/palette/general.json"
 
         /**
          * Создает extension [ThemeBuilderExtension]

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
@@ -142,6 +142,7 @@ internal class GeneratorFactory(
      */
     fun createColorGenerator(
         colors: Map<String, String>,
+        palette: Map<String, Map<String, String>>,
     ): ColorTokenGenerator {
         return ColorTokenGenerator(
             outputLocation = OutputLocation.Directory(outputDir),
@@ -151,13 +152,17 @@ internal class GeneratorFactory(
             ktFileBuilderFactory = ktFileBuilderFactory,
             colorTokenValues = colors,
             resourceReferenceProvider = resourceReferenceProvider,
+            palette = palette,
         )
     }
 
     /**
      * Создает генератор градиентов [GradientGenerator]
      */
-    fun createGradientGenerator(gradients: Map<String, List<GradientTokenValue>>): GradientGenerator {
+    fun createGradientGenerator(
+        gradients: Map<String, List<GradientTokenValue>>,
+        palette: Map<String, Map<String, String>>,
+    ): GradientGenerator {
         return GradientGenerator(
             OutputLocation.Directory(outputDir),
             outputResDir,
@@ -165,6 +170,7 @@ internal class GeneratorFactory(
             xmlResourcesDocumentBuilderFactory,
             ktFileBuilderFactory,
             gradients,
+            palette,
         )
     }
 

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeColorAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeColorAttributeGenerator.kt
@@ -7,6 +7,7 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.ColorTokenResult
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
+import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор Compose-атрибутов цвета.
@@ -28,7 +29,7 @@ internal class ComposeColorAttributeGenerator(
         ktFileBuilderFactory.create(colorClassName)
     }
 
-    private val colorClassName = "${themeName}Colors"
+    private val colorClassName = "${themeName.capitalized()}Colors"
 
     override fun generate() {
         if (colors.isEmpty()) return

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeGradientAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeGradientAttributeGenerator.kt
@@ -9,6 +9,7 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileFromResourcesBuilderF
 import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.GradientTokenResult
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
+import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор Compose-атрибутов градиента.
@@ -36,7 +37,7 @@ internal class ComposeGradientAttributeGenerator(
         ktFileFromResourcesBuilderFactory.create()
     }
 
-    private val gradientClassName = "${themeName}Gradients"
+    private val gradientClassName = "${themeName.capitalized()}Gradients"
 
     fun setGradientTokenData(gradients: List<GradientTokenResult.TokenData>) {
         this.gradients.clear()

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeShapeAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeShapeAttributeGenerator.kt
@@ -7,6 +7,7 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.ShapeTokenResult
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
+import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор Compose-атрибутов форм.
@@ -27,7 +28,7 @@ internal class ComposeShapeAttributeGenerator(
         ktFileBuilderFactory.create(shapeClassName)
     }
 
-    private val shapeClassName = "${themeName}Shapes"
+    private val shapeClassName = "${themeName.capitalized()}Shapes"
 
     fun setShapeTokenData(shapes: List<ShapeTokenResult.TokenData>) {
         this.shapes.clear()

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorUtils.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorUtils.kt
@@ -1,0 +1,69 @@
+package com.sdds.plugin.themebuilder.internal.utils
+
+private const val RGBA_STR_LENGTH = 9
+private const val RGB_STR_LENGTH = 7
+private const val RGBA_ALPHA_INDEX_START = 7
+
+/**
+ * Переводит цвет из формата rgba или ссылки на палитру в argb hex значение
+ *
+ * @param tokenValue входное значение цвета
+ * @param palette палитра цветов
+ * @param hexFormat выходной hex-формат
+ *
+ * @return Вернет строку в формате argb или null в случае неудачи.
+ */
+internal fun resolveColor(
+    tokenValue: String,
+    palette: Map<String, Map<String, String>>,
+    hexFormat: HexFormat,
+): String? {
+    val isPaletteRef = tokenValue.startsWith('[') && tokenValue.endsWith(']')
+    val rgbaHex = if (isPaletteRef) {
+        val paletteTokens = tokenValue
+            .removePrefix("[")
+            .removeSuffix("]")
+            .split('.')
+        val (color, tone) = paletteTokens
+            .subList(1, paletteTokens.size)
+        palette[color]?.get(tone)
+    } else {
+        tokenValue
+    }
+    return rgbaHex?.let { colorToArgbHex(it, hexFormat) }
+}
+
+/**
+ * Формат hex значения цвета.
+ */
+internal enum class HexFormat(val hexPrefix: String) {
+    XML_HEX("#"),
+    INT_HEX("0x"),
+}
+
+/**
+ * Преобразует строку цвета [rgba] вида #FFFFFFE5 в строку вида #E5FFFFFF или 0xE5FFFFFF
+ * в зависимости от [hexFormat].
+ * Также изменяет порядковый номер альфа-канала или добавляет его, если он отсутствует
+ * в исходной строке. Т.е. RGBA -> ARGB или RGB -> ARGB
+ */
+private fun colorToArgbHex(rgba: String, hexFormat: HexFormat): String {
+    if (rgba.length == RGB_STR_LENGTH) {
+        return when (hexFormat) {
+            HexFormat.XML_HEX -> rgba.replace("#", "#FF")
+            HexFormat.INT_HEX -> rgba.replace("#", "0xFF")
+        }
+    }
+    if (rgba.length != RGBA_STR_LENGTH) {
+        return when (hexFormat) {
+            HexFormat.XML_HEX -> rgba
+            HexFormat.INT_HEX -> rgba.replace("#", "0x")
+        }
+    }
+
+    return buildString {
+        append(hexFormat.hexPrefix)
+        append(rgba.subSequence(RGBA_ALPHA_INDEX_START, RGBA_STR_LENGTH))
+        append(rgba.subSequence(1, RGBA_ALPHA_INDEX_START))
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtils.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtils.kt
@@ -3,9 +3,6 @@ package com.sdds.plugin.themebuilder.internal.utils
 import java.util.Locale
 
 private val camelRegex = "(?<=[a-zA-Z])[A-Z]".toRegex()
-private const val RGBA_STR_LENGTH = 9
-private const val RGB_STR_LENGTH = 7
-private const val RGBA_ALPHA_INDEX_START = 7
 
 /**
  * Переводит строку из формата CamelCase в формат snake_case
@@ -29,21 +26,6 @@ internal fun String.techToSnakeCase(): String {
 internal fun String.withPrefixIfNeed(prefix: String? = null, delimiter: String = "_"): String {
     if (prefix.isNullOrBlank()) return this
     return "${prefix}${delimiter}$this"
-}
-
-/**
- * Преобразует строку цвета [rgba] вида #FFFFFFFF в строку вида 0xFFFFFFFF.
- * Также изменяет порядковый номер альфа-канала или добавляет его, если он отсутствует
- * в исходной строке. Т.е. RGBA -> ARGB или RGB -> ARGB
- */
-internal fun colorToArgbHex(rgba: String): String {
-    if (rgba.length == RGB_STR_LENGTH) return rgba.replace("#", "0xFF")
-    if (rgba.length != RGBA_STR_LENGTH) return rgba.replace("#", "0x")
-    return buildString {
-        append("0x")
-        append(rgba.subSequence(RGBA_ALPHA_INDEX_START, RGBA_STR_LENGTH))
-        append(rgba.subSequence(1, RGBA_ALPHA_INDEX_START))
-    }
 }
 
 /**

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/ColorTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/ColorTokenGeneratorTest.kt
@@ -56,6 +56,7 @@ class ColorTokenGeneratorTest {
             ktFileBuilderFactory = KtFileBuilderFactory("com.test"),
             colorTokenValues = colorTokenValues,
             resourceReferenceProvider = ResourceReferenceProvider("thmbldr"),
+            palette = palette,
         )
     }
 
@@ -72,13 +73,13 @@ class ColorTokenGeneratorTest {
     @Test
     fun `ColorGenerator добавляет токен и генерирует файлы для compose и view system`() {
         val input = getResourceAsText("inputs/test-color-input.json")
-        val colorToken = Serializer.meta.decodeFromString<ColorToken>(input)
+        val colors = Serializer.meta.decodeFromString<List<ColorToken>>(input)
         val outputXml = ByteArrayOutputStream()
         val colorsXmlFile = mockk<File>(relaxed = true)
         every { colorsXmlFile.fileWriter() } returns outputXml.writer()
         every { mockOutputResDir.colorsXmlFile() } returns colorsXmlFile
 
-        underTest.addToken(colorToken)
+        colors.forEach(underTest::addToken)
         underTest.generate()
 
         assertEquals(getResourceAsText("color-outputs/test-color-output.xml"), outputXml.toString())
@@ -86,6 +87,12 @@ class ColorTokenGeneratorTest {
     }
 
     private companion object {
-        val colorTokenValues = mapOf("dark.on-light.surface.transparent-accent" to "#FFFFFF1F")
+        val colorTokenValues = mapOf(
+            "dark.on-light.surface.transparent-accent" to "#FFFFFF1F",
+            "dark.surface.transparent-accent" to "[general.green.1000]",
+        )
+        val palette = mapOf(
+            "green" to mapOf("1000" to "#EEEEEE1F"),
+        )
     }
 }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientGeneratorTest.kt
@@ -55,6 +55,7 @@ class GradientGeneratorTest {
             xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr"),
             ktFileBuilderFactory = KtFileBuilderFactory("com.test"),
             gradientTokenValues = gradientTokenValues,
+            mockk(),
         )
     }
 

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorUtilsKtTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorUtilsKtTest.kt
@@ -1,0 +1,34 @@
+package com.sdds.plugin.themebuilder.internal.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ColorUtilsKtTest {
+
+    @Test
+    fun testResolveColor() {
+        assertEquals("0xFFF", resolveColor("#FFF", palette, HexFormat.INT_HEX))
+        assertEquals("0xFFABABAB", resolveColor("#ABABAB", palette, HexFormat.INT_HEX))
+        assertEquals("0xFFABABAB", resolveColor("#ABABABFF", palette, HexFormat.INT_HEX))
+        assertEquals("0xFFABABAB", resolveColor("[general.red.100]", palette, HexFormat.INT_HEX))
+        assertEquals("0xFFEEEEEE", resolveColor("[general.green.1000]", palette, HexFormat.INT_HEX))
+
+        assertEquals("#FFF", resolveColor("#FFF", palette, HexFormat.XML_HEX))
+        assertEquals("#FFABABAB", resolveColor("#ABABAB", palette, HexFormat.XML_HEX))
+        assertEquals("#FFABABAB", resolveColor("#ABABABFF", palette, HexFormat.XML_HEX))
+        assertEquals("#FFABABAB", resolveColor("[general.red.100]", palette, HexFormat.XML_HEX))
+        assertEquals("#FFEEEEEE", resolveColor("[general.green.1000]", palette, HexFormat.XML_HEX))
+    }
+
+    private companion object {
+        val palette = mapOf(
+            "red" to mapOf(
+                "100" to "#ABABAB",
+                "150" to "#000000",
+            ),
+            "green" to mapOf(
+                "1000" to "#EEEEEEFF",
+            ),
+        )
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtilsKtTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtilsKtTest.kt
@@ -29,13 +29,6 @@ class StringUtilsKtTest {
     }
 
     @Test
-    fun testColorToArgbHex() {
-        assertEquals("0xFFF", colorToArgbHex("#FFF"))
-        assertEquals("0xFFABABAB", colorToArgbHex("#ABABAB"))
-        assertEquals("0xFFABABAB", colorToArgbHex("#ABABABFF"))
-    }
-
-    @Test
     fun testFileNameFromUrl() {
         assertEquals("file.zip", "https//google.com/file.zip".fileNameFromUrl())
         assertEquals("file.jpeg", "https//yandex.ru/folder/file.jpeg".fileNameFromUrl())

--- a/sdds-core/plugin_theme_builder/src/test/resources/color-outputs/TestColorOutputKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/color-outputs/TestColorOutputKt.txt
@@ -7,4 +7,9 @@ public object DarkColorTokens {
      * Прозрачная акцентная поверхность
      */
     public val OnLightSurfaceTransparentAccent: Color = Color(0x1FFFFFFF)
+
+    /**
+     * Прозрачная акцентная поверхность
+     */
+    public val SurfaceTransparentAccent: Color = Color(0x1FEEEEEE)
 }

--- a/sdds-core/plugin_theme_builder/src/test/resources/color-outputs/test-color-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/color-outputs/test-color-output.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!--Прозрачная акцентная поверхность-->
-    <color name="thmbldr_dark_on_light_surface_transparent_accent">#FFFFFF1F</color>
+    <color name="thmbldr_dark_on_light_surface_transparent_accent">#1FFFFFFF</color>
+    <!--Прозрачная акцентная поверхность-->
+    <color name="thmbldr_dark_surface_transparent_accent">#1FEEEEEE</color>
 </resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/inputs/test-color-input.json
+++ b/sdds-core/plugin_theme_builder/src/test/resources/inputs/test-color-input.json
@@ -1,12 +1,26 @@
-{
-  "displayName": "onLightSurfaceTransparentAccent",
-  "name": "dark.on-light.surface.transparent-accent",
-  "tags" : [
-    "dark",
-    "surface",
-    "on-light"
-  ],
-  "type": "color",
-  "description": "Прозрачная акцентная поверхность",
-  "enabled": true
-}
+[
+  {
+    "displayName": "onLightSurfaceTransparentAccent",
+    "name": "dark.on-light.surface.transparent-accent",
+    "tags" : [
+      "dark",
+      "surface",
+      "on-light"
+    ],
+    "type": "color",
+    "description": "Прозрачная акцентная поверхность",
+    "enabled": true
+  },
+  {
+    "displayName": "surfaceTransparentAccent",
+    "name": "dark.surface.transparent-accent",
+    "tags" : [
+      "dark",
+      "surface",
+      "on-light"
+    ],
+    "type": "color",
+    "description": "Прозрачная акцентная поверхность",
+    "enabled": true
+  }
+]


### PR DESCRIPTION
* Реализовал поддержку цветовой палитры для темы. Палитра качается в отдельной таске, на которую зависят последующие таски по выкачке темы.
* Расширил утилиту по переводу цвета в argb формат, добавил поддержку хекса с решеткой для xml.