### PR TITLE
feat(sdds-acore/theme-builder): Merge typography tokens

### DIFF
--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
@@ -4,12 +4,12 @@ import com.sdds.plugin.themebuilder.internal.ThemeBuilderTarget
 import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder.OutputLocation
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
 import com.sdds.plugin.themebuilder.internal.generator.ColorTokenGenerator
-import com.sdds.plugin.themebuilder.internal.generator.DimenGenerator
-import com.sdds.plugin.themebuilder.internal.generator.FontGenerator
-import com.sdds.plugin.themebuilder.internal.generator.GradientGenerator
-import com.sdds.plugin.themebuilder.internal.generator.ShadowGenerator
-import com.sdds.plugin.themebuilder.internal.generator.ShapeGenerator
-import com.sdds.plugin.themebuilder.internal.generator.TypographyGenerator
+import com.sdds.plugin.themebuilder.internal.generator.DimenTokenGenerator
+import com.sdds.plugin.themebuilder.internal.generator.FontTokenGenerator
+import com.sdds.plugin.themebuilder.internal.generator.GradientTokenGenerator
+import com.sdds.plugin.themebuilder.internal.generator.ShadowTokenGenerator
+import com.sdds.plugin.themebuilder.internal.generator.ShapeTokenGenerator
+import com.sdds.plugin.themebuilder.internal.generator.TypographyTokenGenerator
 import com.sdds.plugin.themebuilder.internal.generator.theme.ThemeGenerator
 import com.sdds.plugin.themebuilder.internal.token.FontTokenValue
 import com.sdds.plugin.themebuilder.internal.token.GradientTokenValue
@@ -181,13 +181,13 @@ internal class GeneratorFactory(
     }
 
     /**
-     * Создает генератор градиентов [GradientGenerator]
+     * Создает генератор градиентов [GradientTokenGenerator]
      */
     fun createGradientGenerator(
         gradients: Map<String, List<GradientTokenValue>>,
         palette: Map<String, Map<String, String>>,
-    ): GradientGenerator {
-        return GradientGenerator(
+    ): GradientTokenGenerator {
+        return GradientTokenGenerator(
             OutputLocation.Directory(outputDir),
             outputResDir,
             target,
@@ -200,10 +200,10 @@ internal class GeneratorFactory(
     }
 
     /**
-     * Создает генератор шрифтов [FontGenerator]
+     * Создает генератор шрифтов [FontTokenGenerator]
      */
-    fun createFontGenerator(fonts: Map<String, FontTokenValue>): FontGenerator {
-        return FontGenerator(
+    fun createFontGenerator(fonts: Map<String, FontTokenValue>): FontTokenGenerator {
+        return FontTokenGenerator(
             OutputLocation.Directory(outputDir),
             outputResDir,
             target,
@@ -217,10 +217,10 @@ internal class GeneratorFactory(
     }
 
     /**
-     * Создает генератор типографии [TypographyGenerator]
+     * Создает генератор типографии [TypographyTokenGenerator]
      */
-    fun createTypographyGenerator(typography: Map<String, TypographyTokenValue>): TypographyGenerator {
-        return TypographyGenerator(
+    fun createTypographyGenerator(typography: Map<String, TypographyTokenValue>): TypographyTokenGenerator {
+        return TypographyTokenGenerator(
             OutputLocation.Directory(outputDir),
             outputResDir,
             target,
@@ -233,10 +233,10 @@ internal class GeneratorFactory(
     }
 
     /**
-     * Создает генератор размеров [DimenGenerator]
+     * Создает генератор размеров [DimenTokenGenerator]
      */
-    fun createDimensGenerator(): DimenGenerator {
-        return DimenGenerator(
+    fun createDimensGenerator(): DimenTokenGenerator {
+        return DimenTokenGenerator(
             outputResDir,
             dimensAggregator,
             xmlResourcesDocumentBuilderFactory,
@@ -244,10 +244,10 @@ internal class GeneratorFactory(
     }
 
     /**
-     * Создает генератор форм [ShapeGenerator]
+     * Создает генератор форм [ShapeTokenGenerator]
      */
-    fun createShapesGenerator(shapes: Map<String, ShapeTokenValue>): ShapeGenerator {
-        return ShapeGenerator(
+    fun createShapesGenerator(shapes: Map<String, ShapeTokenValue>): ShapeTokenGenerator {
+        return ShapeTokenGenerator(
             OutputLocation.Directory(outputDir),
             outputResDir,
             target,
@@ -260,10 +260,10 @@ internal class GeneratorFactory(
     }
 
     /**
-     * Создает генератор теней [ShadowGenerator]
+     * Создает генератор теней [ShadowTokenGenerator]
      */
-    fun createShadowGenerator(shadows: Map<String, ShadowTokenValue>): ShadowGenerator {
-        return ShadowGenerator(
+    fun createShadowGenerator(shadows: Map<String, ShadowTokenValue>): ShadowTokenGenerator {
+        return ShadowTokenGenerator(
             OutputLocation.Directory(outputDir),
             outputResDir,
             target,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/DimenTokenGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/DimenTokenGenerator.kt
@@ -17,7 +17,7 @@ import java.io.File
  * @param xmlBuilderFactory фабрика делегата построения xml файлов
  * @author Малышев Александр on 07.03.2024
  */
-internal class DimenGenerator(
+internal class DimenTokenGenerator(
     private val outputResDir: File,
     private val dimensAggregator: DimensAggregator,
     private val xmlBuilderFactory: XmlResourcesDocumentBuilderFactory,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/FontTokenGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/FontTokenGenerator.kt
@@ -27,7 +27,7 @@ import java.util.Locale
  * @param resPrefix префикс для xml файлов с fontFamily
  * @author Малышев Александр on 07.03.2024
  */
-internal class FontGenerator(
+internal class FontTokenGenerator(
     private val outputLocation: KtFileBuilder.OutputLocation,
     private val outputResDir: File,
     target: ThemeBuilderTarget,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientTokenGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientTokenGenerator.kt
@@ -38,7 +38,7 @@ import java.util.Locale
  * @param ktFileBuilderFactory фабрика делегата построения kt файлов
  * @author Малышев Александр on 07.03.2024
  */
-internal class GradientGenerator(
+internal class GradientTokenGenerator(
     private val outputLocation: KtFileBuilder.OutputLocation,
     private val outputResDir: File,
     target: ThemeBuilderTarget,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/ShadowTokenGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/ShadowTokenGenerator.kt
@@ -22,7 +22,7 @@ import java.io.File
  * @param ktFileBuilderFactory фабрика делегата построения kt файлов
  * @author Малышев Александр on 07.03.2024
  */
-internal class ShadowGenerator(
+internal class ShadowTokenGenerator(
     private val outputLocation: KtFileBuilder.OutputLocation,
     private val outputResDir: File,
     target: ThemeBuilderTarget,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/ShapeTokenGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/ShapeTokenGenerator.kt
@@ -31,7 +31,7 @@ import java.util.Locale
  * @param resourceReferenceProvider провайдер ссылок на ресурсы
  * @author Малышев Александр on 07.03.2024
  */
-internal class ShapeGenerator(
+internal class ShapeTokenGenerator(
     private val outputLocation: KtFileBuilder.OutputLocation,
     private val outputResDir: File,
     target: ThemeBuilderTarget,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyGenerator.kt
@@ -8,10 +8,12 @@ import com.sdds.plugin.themebuilder.internal.builder.XmlResourcesDocumentBuilder
 import com.sdds.plugin.themebuilder.internal.builder.XmlResourcesDocumentBuilder.TargetApi
 import com.sdds.plugin.themebuilder.internal.dimens.DimenData
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
+import com.sdds.plugin.themebuilder.internal.exceptions.ThemeBuilderException
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.XmlResourcesDocumentBuilderFactory
 import com.sdds.plugin.themebuilder.internal.generator.data.TypographyTokenResult
 import com.sdds.plugin.themebuilder.internal.token.TypographyToken
+import com.sdds.plugin.themebuilder.internal.token.TypographyToken.ScreenClass
 import com.sdds.plugin.themebuilder.internal.token.TypographyTokenValue
 import com.sdds.plugin.themebuilder.internal.utils.FileProvider.textAppearancesXmlFile
 import com.sdds.plugin.themebuilder.internal.utils.FileProvider.typographyXmlFile
@@ -42,7 +44,7 @@ internal class TypographyGenerator(
 ) : TokenGenerator<TypographyToken, TypographyTokenResult>(target) {
 
     private val textAppearanceXmlBuilders =
-        mutableMapOf<TypographyToken.ScreenClass, XmlResourcesDocumentBuilder>()
+        mutableMapOf<ScreenClass, XmlResourcesDocumentBuilder>()
     private val typographyXmlBuilder by unsafeLazy {
         xmlBuilderFactory.create(DEFAULT_ROOT_ATTRIBUTES)
     }
@@ -52,12 +54,25 @@ internal class TypographyGenerator(
     private val smallBuilder by unsafeLazy { ktFileBuilder.rootObject(TYPOGRAPHY_SMALL_TOKENS_NAME) }
     private var needDeclareStyle: Boolean = true
 
-    private val composeTokenDataCollector = mutableListOf<TypographyTokenResult.ComposeTokenData>()
-    private val viewTokenDataCollector = mutableListOf<TypographyTokenResult.ViewTokenData>()
+    private val composeSmallTokenDataCollector = mutableMapOf<String, String>()
+    private val composeMediumTokenDataCollector = mutableMapOf<String, String>()
+    private val composeLargeTokenDataCollector = mutableMapOf<String, String>()
+
+    private val viewTokenDataCollector = mutableMapOf<String, String>()
+
+    private val viewSmallTokens = mutableMapOf<String, TypographyToken>()
+    private val viewMediumTokens = mutableMapOf<String, TypographyToken>()
+    private val viewLargeTokens = mutableMapOf<String, TypographyToken>()
 
     override fun collectResult() = TypographyTokenResult(
-        composeTokens = composeTokenDataCollector,
-        viewTokens = viewTokenDataCollector,
+        composeTokens = TypographyTokenResult.ComposeTokenData(
+            small = composeSmallTokenDataCollector,
+            medium = composeMediumTokenDataCollector,
+            large = composeLargeTokenDataCollector,
+        ),
+        viewTokens = TypographyTokenResult.ViewTokenData(
+            attrs = viewTokenDataCollector,
+        ),
     )
 
     /**
@@ -65,6 +80,15 @@ internal class TypographyGenerator(
      */
     override fun generateViewSystem() {
         super.generateViewSystem()
+
+        val mergedTokenKeys = viewSmallTokens.keys + viewMediumTokens.keys + viewLargeTokens.keys
+
+        mergedTokenKeys.forEach {
+            generateTypographyTokens(tokenName = it, screenClass = ScreenClass.SMALL)
+            generateTypographyTokens(tokenName = it, screenClass = ScreenClass.MEDIUM)
+            generateTypographyTokens(tokenName = it, screenClass = ScreenClass.LARGE)
+        }
+
         textAppearanceXmlBuilders.forEach {
             it.value.build(outputResDir.textAppearancesXmlFile(it.key.qualifier()))
         }
@@ -85,22 +109,76 @@ internal class TypographyGenerator(
      * @see TokenGenerator.addViewSystemToken
      */
     override fun addViewSystemToken(token: TypographyToken): Boolean {
+        val tokenXmlName = token.xmlName
+        when (token.screenClass) {
+            ScreenClass.SMALL -> viewSmallTokens[tokenXmlName] = token
+            ScreenClass.LARGE -> viewLargeTokens[tokenXmlName] = token
+            else -> viewMediumTokens[tokenXmlName] = token
+        }
+        return true
+    }
+
+    /**
+     * @see TokenGenerator.addComposeToken
+     */
+    override fun addComposeToken(token: TypographyToken): Boolean {
         val tokenValue = typographyTokenValues[token.name] ?: return false
+        val attrName = token.ktName.decapitalize(Locale.getDefault())
+        when (token.screenClass) {
+            ScreenClass.SMALL -> {
+                smallBuilder.addTypographyToken(
+                    token.ktName,
+                    token.description,
+                    tokenValue,
+                )
+                val tokenRef = "$TYPOGRAPHY_SMALL_TOKENS_NAME.${token.ktName}"
+                composeSmallTokenDataCollector[attrName] = tokenRef
+            }
+
+            ScreenClass.LARGE -> {
+                largeBuilder.addTypographyToken(
+                    token.ktName,
+                    token.description,
+                    tokenValue,
+                )
+                val tokenRef = "$TYPOGRAPHY_LARGE_TOKENS_NAME.${token.ktName}"
+                composeLargeTokenDataCollector[attrName] = tokenRef
+            }
+
+            else -> {
+                mediumBuilder.addTypographyToken(
+                    token.ktName,
+                    token.description,
+                    tokenValue,
+                )
+                val tokenRef = "$TYPOGRAPHY_MEDIUM_TOKENS_NAME.${token.ktName}"
+                composeMediumTokenDataCollector[attrName] = tokenRef
+            }
+        }
+        return true
+    }
+
+    private fun generateTypographyTokens(tokenName: String, screenClass: ScreenClass) {
+        val token = findTypographyTokenByScreenClass(tokenName, screenClass)
+            ?: throw ThemeBuilderException("Token $tokenName not found")
+        val tokenValue = typographyTokenValues[token.name]
+            ?: throw ThemeBuilderException(
+                "Value for token ${token.name} must be presented in android_typography.json",
+            )
         val builder =
-            textAppearanceXmlBuilders[token.screenClass] ?: xmlBuilderFactory.create(
+            textAppearanceXmlBuilders[screenClass] ?: xmlBuilderFactory.create(
                 DEFAULT_ROOT_ATTRIBUTES,
             ).also {
-                textAppearanceXmlBuilders[token.screenClass] = it
+                textAppearanceXmlBuilders[screenClass] = it
             }
         val textAppearanceName = "TextAppearance.${token.xmlName}"
-        val typographyName = "Typography.${token.xmlName}"
-
-        if (token.screenClass.isDefault) {
+        if (screenClass == ScreenClass.MEDIUM) {
             if (needDeclareStyle) {
                 needDeclareStyle = false
                 builder.appendStyleWithPrefix("TextAppearance")
                 typographyXmlBuilder.appendStyleWithPrefix("Typography")
             }
+            val typographyName = "Typography.${token.xmlName}"
             with(typographyXmlBuilder) {
                 appendComment(token.description)
                 appendStyleWithPrefix(typographyName) {
@@ -112,78 +190,31 @@ internal class TypographyGenerator(
                     )
                 }
             }
-            viewTokenDataCollector.add(
-                TypographyTokenResult.ViewTokenData(
-                    attrName = "typography${token.xmlName}",
-                    tokenRefName = resourceReferenceProvider.style(typographyName),
-                ),
-            )
+            val attrName = "typography${token.xmlName}"
+            val tokenRef = resourceReferenceProvider.style(typographyName)
+            viewTokenDataCollector[attrName] = tokenRef
         }
         builder.appendComment(token.description)
         builder.appendTypographyToken(token, tokenValue, textAppearanceName)
-        return true
     }
 
-    /**
-     * @see TokenGenerator.addComposeToken
-     */
-    override fun addComposeToken(token: TypographyToken): Boolean {
-        val tokenValue = typographyTokenValues[token.name] ?: return false
-        when (token.screenClass) {
-            TypographyToken.ScreenClass.SMALL -> {
-                smallBuilder.addTypographyToken(
-                    token.ktName,
-                    token.description,
-                    tokenValue,
-                )
-                addTokenData(
-                    token = token,
-                    tokenContainerName = TYPOGRAPHY_SMALL_TOKENS_NAME,
-                    screen = TypographyTokenResult.ComposeTokenData.Screen.SMALL,
-                )
-            }
+    private fun findTypographyTokenByScreenClass(
+        tokenName: String,
+        screenClass: ScreenClass,
+    ): TypographyToken? {
+        return when (screenClass) {
+            ScreenClass.SMALL -> viewSmallTokens[tokenName]
+                ?: viewMediumTokens[tokenName]
+                ?: viewLargeTokens[tokenName]
 
-            TypographyToken.ScreenClass.LARGE -> {
-                largeBuilder.addTypographyToken(
-                    token.ktName,
-                    token.description,
-                    tokenValue,
-                )
-                addTokenData(
-                    token = token,
-                    tokenContainerName = TYPOGRAPHY_LARGE_TOKENS_NAME,
-                    screen = TypographyTokenResult.ComposeTokenData.Screen.LARGE,
-                )
-            }
+            ScreenClass.LARGE -> viewLargeTokens[tokenName]
+                ?: viewMediumTokens[tokenName]
+                ?: viewSmallTokens[tokenName]
 
-            else -> {
-                mediumBuilder.addTypographyToken(
-                    token.ktName,
-                    token.description,
-                    tokenValue,
-                )
-                addTokenData(
-                    token = token,
-                    tokenContainerName = TYPOGRAPHY_MEDIUM_TOKENS_NAME,
-                    screen = TypographyTokenResult.ComposeTokenData.Screen.MEDIUM,
-                )
-            }
+            else -> viewMediumTokens[tokenName]
+                ?: viewSmallTokens[tokenName]
+                ?: viewLargeTokens[tokenName]
         }
-        return true
-    }
-
-    private fun addTokenData(
-        token: TypographyToken,
-        tokenContainerName: String,
-        screen: TypographyTokenResult.ComposeTokenData.Screen,
-    ) {
-        composeTokenDataCollector.add(
-            TypographyTokenResult.ComposeTokenData(
-                attrName = token.ktName.decapitalize(Locale.getDefault()),
-                tokenRefName = "$tokenContainerName.${token.ktName}",
-                screen = screen,
-            ),
-        )
     }
 
     private fun XmlResourcesDocumentBuilder.appendTypographyToken(
@@ -278,10 +309,10 @@ internal class TypographyGenerator(
         const val TYPOGRAPHY_MEDIUM_TOKENS_NAME = "TypographyMediumTokens"
         const val TYPOGRAPHY_LARGE_TOKENS_NAME = "TypographyLargeTokens"
 
-        fun TypographyToken.ScreenClass.qualifier(): String {
+        fun ScreenClass.qualifier(): String {
             return when (this) {
-                TypographyToken.ScreenClass.SMALL -> "small"
-                TypographyToken.ScreenClass.LARGE -> "large"
+                ScreenClass.SMALL -> "small"
+                ScreenClass.LARGE -> "large"
                 else -> ""
             }
         }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyGenerator.kt
@@ -84,9 +84,9 @@ internal class TypographyGenerator(
         val mergedTokenKeys = viewSmallTokens.keys + viewMediumTokens.keys + viewLargeTokens.keys
 
         mergedTokenKeys.forEach {
-            generateTypographyTokens(tokenName = it, screenClass = ScreenClass.SMALL)
-            generateTypographyTokens(tokenName = it, screenClass = ScreenClass.MEDIUM)
-            generateTypographyTokens(tokenName = it, screenClass = ScreenClass.LARGE)
+            generateViewTypographyTokens(tokenName = it, screenClass = ScreenClass.SMALL)
+            generateViewTypographyTokens(tokenName = it, screenClass = ScreenClass.MEDIUM)
+            generateViewTypographyTokens(tokenName = it, screenClass = ScreenClass.LARGE)
         }
 
         textAppearanceXmlBuilders.forEach {
@@ -158,7 +158,7 @@ internal class TypographyGenerator(
         return true
     }
 
-    private fun generateTypographyTokens(tokenName: String, screenClass: ScreenClass) {
+    private fun generateViewTypographyTokens(tokenName: String, screenClass: ScreenClass) {
         val token = findTypographyTokenByScreenClass(tokenName, screenClass)
             ?: throw ThemeBuilderException("Token $tokenName not found")
         val tokenValue = typographyTokenValues[token.name]

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGenerator.kt
@@ -25,6 +25,14 @@ import java.io.File
 import java.util.Locale
 
 /**
+ * Генерирует токены типографики.
+ *
+ * В этом генераторе механизмы генерации и формирования результата для View и Compose имеют существенные различия.
+ * Compose-токены сразу добавляются в соответствующие объекты для small/medium/large экранов,
+ * а результат генерации размещается в 3 соответствующих словаря. View-токены сначала агрегируются в 3 словаря,
+ * затем textAppearance раскладываются по трем файлам, а результат генерации содержит 1 словарь,
+ * т.к. ссылка на токен типографики в xml идентичная для всех типов экранов.
+ *
  * @param outputLocation локация для сохранения kt-файла с токенами
  * @param outputResDir директория для сохранения xml-файла с токенами
  * @param target целевой фреймворк
@@ -32,7 +40,7 @@ import java.util.Locale
  * @param ktFileBuilderFactory фабрика делегата построения kt файлов
  * @author Малышев Александр on 07.03.2024
  */
-internal class TypographyGenerator(
+internal class TypographyTokenGenerator(
     private val outputLocation: KtFileBuilder.OutputLocation,
     private val outputResDir: File,
     target: ThemeBuilderTarget,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/data/GradientTokenResult.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/data/GradientTokenResult.kt
@@ -58,7 +58,3 @@ internal data class GradientTokenResult(
 internal fun GradientTokenResult.ComposeTokenData.mergedLightAndDark(): Set<String> {
     return light.keys + dark.keys
 }
-
-internal fun GradientTokenResult.ViewTokenData.mergedLightAndDark(): Set<String> {
-    return light.keys + dark.keys
-}

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/data/TypographyTokenResult.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/data/TypographyTokenResult.kt
@@ -7,35 +7,33 @@ package com.sdds.plugin.themebuilder.internal.generator.data
  * @property viewTokens данные о токенах для View
  */
 internal data class TypographyTokenResult(
-    val composeTokens: List<ComposeTokenData>,
-    val viewTokens: List<ViewTokenData>,
+    val composeTokens: ComposeTokenData,
+    val viewTokens: ViewTokenData,
 ) {
 
     /**
-     * Данные о добавленном токене для View
+     * Данные о добавленных токенах для Compose
      *
-     * @property attrName название атрибута токена
-     * @property tokenRefName ссылка на сгенерированный токен
+     * @property small атрибуты типографики для маленьких экранов
+     * @property medium атрибуты типографики для средних экранов
+     * @property large атрибуты типографики для больших экранов
      */
-    internal data class ViewTokenData(
-        val attrName: String,
-        val tokenRefName: String,
+    internal data class ComposeTokenData(
+        val small: Map<String, String>,
+        val medium: Map<String, String>,
+        val large: Map<String, String>,
     )
 
     /**
-     * Данные о добавленном токене для Compose
+     * Данные о добавленных токенах для View
      *
-     * @property attrName название атрибута токена
-     * @property tokenRefName ссылка на сгенерированный токен
-     * @property screen тип экрана
+     * @property attrs атрибуты типографики (ключ - название атрибута, значение - ссылка на токен)
      */
-    internal data class ComposeTokenData(
-        val attrName: String,
-        val tokenRefName: String,
-        val screen: Screen,
-    ) {
-        internal enum class Screen {
-            SMALL, MEDIUM, LARGE
-        }
-    }
+    internal data class ViewTokenData(
+        val attrs: Map<String, String>,
+    )
+}
+
+internal fun TypographyTokenResult.ComposeTokenData.mergedScreenClasses(): Set<String> {
+    return small.keys + medium.keys + large.keys
 }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeColorAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeColorAttributeGenerator.kt
@@ -52,7 +52,7 @@ internal class ComposeColorAttributeGenerator(
     }
 
     fun setColorTokenData(data: ColorTokenResult.TokenData) {
-        this.tokenData = data
+        tokenData = data
         colorAttributes.clear()
         colorAttributes.addAll(data.mergedLightAndDark())
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeThemeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeThemeGenerator.kt
@@ -6,6 +6,7 @@ import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.ColorTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.TypographyTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedLightAndDark
+import com.sdds.plugin.themebuilder.internal.generator.data.mergedScreenClasses
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
 import org.gradle.configurationcache.extensions.capitalized
 
@@ -210,8 +211,9 @@ internal class ComposeThemeGenerator(
         findDefaultTextStyleColor(attrSet)
     }
 
-    fun setTypographyTokenData(typography: List<TypographyTokenResult.ComposeTokenData>) {
-        findDefaultTextStyle(typography)
+    fun setTypographyTokenData(typography: TypographyTokenResult.ComposeTokenData) {
+        val attrSet = typography.mergedScreenClasses()
+        findDefaultTextStyle(attrSet)
     }
 
     private fun findDefaultSelectionColors(attrSet: Set<String>) {
@@ -230,10 +232,10 @@ internal class ComposeThemeGenerator(
         textStyleColor = textPrimaryColor ?: return
     }
 
-    private fun findDefaultTextStyle(typography: List<TypographyTokenResult.ComposeTokenData>) {
+    private fun findDefaultTextStyle(typography: Set<String>) {
         val bodyMediumNormal = typography.find {
-            it.attrName == "bodyMNormal"
-        }?.attrName
+            it == "bodyMNormal"
+        }
         textStyle = bodyMediumNormal ?: return
     }
 }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewThemeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewThemeGenerator.kt
@@ -32,7 +32,7 @@ internal class ViewThemeGenerator(
     private var colors: ColorTokenResult.TokenData? = null
     private val colorAttributes = mutableSetOf<String>()
     private val shapes = mutableListOf<ShapeTokenResult.TokenData>()
-    private val typography = mutableListOf<TypographyTokenResult.ViewTokenData>()
+    private var typography: TypographyTokenResult.ViewTokenData? = null
 
     private val lightThemeXmlFileBuilder by unsafeLazy {
         xmlBuilderFactory.create()
@@ -53,9 +53,8 @@ internal class ViewThemeGenerator(
         shapes.addAll(data)
     }
 
-    internal fun setTypographyTokenData(data: List<TypographyTokenResult.ViewTokenData>) {
-        typography.clear()
-        typography.addAll(data)
+    internal fun setTypographyTokenData(data: TypographyTokenResult.ViewTokenData) {
+        typography = data
     }
 
     override fun generate() {
@@ -90,21 +89,24 @@ internal class ViewThemeGenerator(
                     appendAttrs(shapes.shapesToThemeAttrs(), this)
                 },
                 {
-                    if (typography.isNotEmpty()) appendComment("Typography")
-                    appendAttrs(typography.typographyToThemeAttrs(), this)
+                    val data = typography?.attrs
+                    if (!data.isNullOrEmpty()) {
+                        appendComment("Typography")
+                        appendAttrs(typography?.attrs.typographyToThemeAttrs(), this)
+                    }
                 },
             )
             build(outputResDir.themeXmlFile(ThemeMode.LIGHT.qualifier))
         }
     }
 
-    private fun List<TypographyTokenResult.ViewTokenData>.typographyToThemeAttrs(): List<ViewThemeAttribute> =
-        map { entry ->
+    private fun Map<String, String>?.typographyToThemeAttrs(): List<ViewThemeAttribute> =
+        this?.map { entry ->
             ViewThemeAttribute(
-                name = entry.attrName,
-                value = entry.tokenRefName,
+                name = entry.key,
+                value = entry.value,
             )
-        }
+        } ?: emptyList()
 
     private fun Set<String>.toDarkThemeAttrs(): List<ViewThemeAttribute> =
         map { color ->

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewTypographyAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewTypographyAttributeGenerator.kt
@@ -20,22 +20,22 @@ internal class ViewTypographyAttributeGenerator(
     private val attrPrefix: String,
 ) : SimpleBaseGenerator {
 
-    private val typography = mutableListOf<TypographyTokenResult.ViewTokenData>()
+    private val typography = mutableSetOf<String>()
 
-    fun setTypographyTokenData(data: List<TypographyTokenResult.ViewTokenData>) {
+    fun setTypographyTokenData(data: TypographyTokenResult.ViewTokenData) {
         typography.clear()
-        typography.addAll(data)
+        typography.addAll(data.attrs.keys)
     }
 
     override fun generate() {
-        appendTypography(typography)
+        appendTypography()
         xmlDocumentBuilder.build(outputResDir.attrsFile("typography"))
     }
 
-    private fun appendTypography(typography: MutableList<TypographyTokenResult.ViewTokenData>) {
+    private fun appendTypography() {
         xmlDocumentBuilder.appendComment("Typography")
         typography.forEach { typographyItem ->
-            appendAttr(typographyItem.attrName.toXmlAttribute())
+            appendAttr(typographyItem.toXmlAttribute())
         }
     }
 

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/ComposeTypographyAttributeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/ComposeTypographyAttributeGeneratorTest.kt
@@ -41,7 +41,6 @@ class ComposeTypographyAttributeGeneratorTest {
             TypeSpec,
             FileProvider,
         )
-        outputKt = ByteArrayOutputStream()
         ktFileBuilder = KtFileBuilder(
             packageName = "com.sdds.playground.themebuilder.tokens",
             fileName = "ThemeColors",
@@ -55,12 +54,6 @@ class ComposeTypographyAttributeGeneratorTest {
         mockKtFileFromResourceBuilderFactory = mockk<KtFileFromResourcesBuilderFactory> {
             every { create() } returns ktFileFromResourcesBuilder
         }
-        underTest = ComposeTypographyAttributeGenerator(
-            ktFileBuilderFactory = mockKtFileBuilderFactory,
-            ktFileFromResourcesBuilderFactory = mockKtFileFromResourceBuilderFactory,
-            outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
-            themeName = "Theme",
-        )
     }
 
     @After
@@ -75,29 +68,108 @@ class ComposeTypographyAttributeGeneratorTest {
 
     @Test
     fun `KtAttributeGenerator должен генерировать kotlin файлы с атрибутами типографики`() {
-        underTest.setTypographyTokenData(inputAttrs)
+        outputKt = ByteArrayOutputStream()
+        underTest = ComposeTypographyAttributeGenerator(
+            ktFileBuilderFactory = mockKtFileBuilderFactory,
+            ktFileFromResourcesBuilderFactory = mockKtFileFromResourceBuilderFactory,
+            outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
+            themeName = "Theme",
+        )
+
+        underTest.setTypographyTokenData(input1)
         underTest.generate()
 
         verify {
             mockKtFileBuilderFactory.create("ThemeTypography")
+            mockKtFileFromResourceBuilderFactory.create()
         }
 
         Assert.assertEquals(
-            getResourceAsText("attrs-outputs/TypographyOutputKt.txt"),
+            getResourceAsText("attrs-outputs/TypographyOutputKt_1.txt"),
+            outputKt.toString(),
+        )
+    }
+
+    @Test
+    fun `KtAttributeGenerator генерирует атрибуты типографики с недостающими токенами`() {
+        outputKt = ByteArrayOutputStream()
+        underTest = ComposeTypographyAttributeGenerator(
+            ktFileBuilderFactory = mockKtFileBuilderFactory,
+            ktFileFromResourcesBuilderFactory = mockKtFileFromResourceBuilderFactory,
+            outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
+            themeName = "Theme",
+        )
+
+        underTest.setTypographyTokenData(input2)
+        underTest.generate()
+
+        verify {
+            mockKtFileBuilderFactory.create("ThemeTypography")
+            mockKtFileFromResourceBuilderFactory.create()
+        }
+
+        Assert.assertEquals(
+            getResourceAsText("attrs-outputs/TypographyOutputKt_2.txt"),
+            outputKt.toString(),
+        )
+    }
+
+    @Test
+    fun `KtAttributeGenerator генерирует атрибуты типографики только на основе large токенов`() {
+        outputKt = ByteArrayOutputStream()
+        underTest = ComposeTypographyAttributeGenerator(
+            ktFileBuilderFactory = mockKtFileBuilderFactory,
+            ktFileFromResourcesBuilderFactory = mockKtFileFromResourceBuilderFactory,
+            outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
+            themeName = "Theme",
+        )
+
+        underTest.setTypographyTokenData(input3)
+        underTest.generate()
+
+        verify {
+            mockKtFileBuilderFactory.create("ThemeTypography")
+            mockKtFileFromResourceBuilderFactory.create()
+        }
+
+        Assert.assertEquals(
+            getResourceAsText("attrs-outputs/TypographyOutputKt_3.txt"),
             outputKt.toString(),
         )
     }
 
     private companion object {
-        val inputAttrs = ComposeTokenData(
+        val input1 = ComposeTokenData(
+            small = mapOf(
+                "displayLNormal" to "TypographySmallTokens.DisplayLNormal",
+                "displayLBold" to "TypographySmallTokens.DisplayLBold",
+            ),
+            medium = mapOf(
+                "displayLNormal" to "TypographyMediumTokens.DisplayLNormal",
+                "displayLBold" to "TypographyMediumTokens.DisplayLBold",
+            ),
+            large = mapOf(
+                "displayLNormal" to "TypographyLargeTokens.DisplayLNormal",
+                "displayLBold" to "TypographyLargeTokens.DisplayLBold",
+            ),
+        )
+        val input2 = ComposeTokenData(
             small = mapOf(
                 "displayLNormal" to "TypographySmallTokens.DisplayLNormal",
             ),
             medium = mapOf(
-                "displayLNormal" to "TypographyMediumTokens.DisplayLNormal",
+                "displayLBold" to "TypographyMediumTokens.DisplayLBold",
             ),
             large = mapOf(
                 "displayLNormal" to "TypographyLargeTokens.DisplayLNormal",
+            ),
+        )
+        val input3 = ComposeTokenData(
+            small = emptyMap(),
+            medium = emptyMap(),
+            large = mapOf(
+                "displayLNormal" to "TypographyLargeTokens.DisplayLNormal",
+                "displayLBold" to "TypographyLargeTokens.DisplayLBold",
             ),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/ComposeTypographyAttributeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/ComposeTypographyAttributeGeneratorTest.kt
@@ -89,21 +89,15 @@ class ComposeTypographyAttributeGeneratorTest {
     }
 
     private companion object {
-        val inputAttrs = listOf(
-            ComposeTokenData(
-                "displayLNormal",
-                "TypographySmallTokens.DisplayLNormal",
-                ComposeTokenData.Screen.SMALL,
+        val inputAttrs = ComposeTokenData(
+            small = mapOf(
+                "displayLNormal" to "TypographySmallTokens.DisplayLNormal",
             ),
-            ComposeTokenData(
-                "displayLNormal",
-                "TypographyMediumTokens.DisplayLNormal",
-                ComposeTokenData.Screen.MEDIUM,
+            medium = mapOf(
+                "displayLNormal" to "TypographyMediumTokens.DisplayLNormal",
             ),
-            ComposeTokenData(
-                "displayLNormal",
-                "TypographyLargeTokens.DisplayLNormal",
-                ComposeTokenData.Screen.LARGE,
+            large = mapOf(
+                "displayLNormal" to "TypographyLargeTokens.DisplayLNormal",
             ),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeLightAndDarkColorsTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeLightAndDarkColorsTest.kt
@@ -1,0 +1,71 @@
+package com.sdds.plugin.themebuilder.internal.attributes.generator
+
+import com.sdds.plugin.themebuilder.internal.generator.data.ColorTokenResult
+import com.sdds.plugin.themebuilder.internal.generator.data.mergedLightAndDark
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class MergeLightAndDarkColorsTest(
+    private val tokenData: ColorTokenResult.TokenData,
+    private val expectedResultSet: Set<String>,
+) {
+
+    @Test
+    fun `mergedLightAndDark() должна возвращать объединение ключей словарей темной и светлой темы`() {
+        Assert.assertEquals(expectedResultSet, tokenData.mergedLightAndDark())
+    }
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data() = listOf(
+            arrayOf(
+                ColorTokenResult.TokenData(
+                    light = mapOf(
+                        "key1" to "value1",
+                        "key2" to "value2",
+                    ),
+                    dark = mapOf(
+                        "key1" to "value1",
+                        "key2" to "value2",
+                    ),
+                ),
+                setOf("key1", "key2"),
+            ),
+            arrayOf(
+                ColorTokenResult.TokenData(
+                    light = mapOf(
+                        "key1" to "value1",
+                        "key2" to "value2",
+                    ),
+                    dark = mapOf(
+                        "key3" to "value3",
+                        "key4" to "value4",
+                    ),
+                ),
+                setOf("key1", "key2", "key3", "key4"),
+            ),
+            arrayOf(
+                ColorTokenResult.TokenData(
+                    light = emptyMap(),
+                    dark = mapOf(
+                        "key3" to "value3",
+                        "key4" to "value4",
+                    ),
+                ),
+                setOf("key3", "key4"),
+            ),
+            arrayOf(
+                ColorTokenResult.TokenData(
+                    light = emptyMap(),
+                    dark = emptyMap(),
+                ),
+                emptySet<String>(),
+            ),
+        )
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeLightAndDarkGradientsTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeLightAndDarkGradientsTest.kt
@@ -1,6 +1,6 @@
 package com.sdds.plugin.themebuilder.internal.attributes.generator
 
-import com.sdds.plugin.themebuilder.internal.generator.data.ColorTokenResult
+import com.sdds.plugin.themebuilder.internal.generator.data.GradientTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedLightAndDark
 import org.junit.Assert
 import org.junit.Test
@@ -8,8 +8,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-internal class MergeLightAndDarkTest(
-    private val tokenData: ColorTokenResult.TokenData,
+internal class MergeLightAndDarkGradientsTest(
+    private val tokenData: GradientTokenResult.ComposeTokenData,
     private val expectedResultSet: Set<String>,
 ) {
 
@@ -19,48 +19,52 @@ internal class MergeLightAndDarkTest(
     }
 
     companion object {
+        private fun getParams(value: String) = GradientTokenResult.ComposeTokenData.Parameters(
+            listOf(value),
+            GradientTokenResult.ComposeTokenData.GradientType.LINEAR,
+        )
 
         @JvmStatic
         @Parameterized.Parameters
         fun data() = listOf(
             arrayOf(
-                ColorTokenResult.TokenData(
+                GradientTokenResult.ComposeTokenData(
                     light = mapOf(
-                        "key1" to "value1",
-                        "key2" to "value2",
+                        "key1" to getParams("value1"),
+                        "key2" to getParams("value2"),
                     ),
                     dark = mapOf(
-                        "key1" to "value1",
-                        "key2" to "value2",
+                        "key1" to getParams("value1"),
+                        "key2" to getParams("value2"),
                     ),
                 ),
                 setOf("key1", "key2"),
             ),
             arrayOf(
-                ColorTokenResult.TokenData(
+                GradientTokenResult.ComposeTokenData(
                     light = mapOf(
-                        "key1" to "value1",
-                        "key2" to "value2",
+                        "key1" to getParams("value1"),
+                        "key2" to getParams("value2"),
                     ),
                     dark = mapOf(
-                        "key3" to "value3",
-                        "key4" to "value4",
+                        "key3" to getParams("value3"),
+                        "key4" to getParams("value4"),
                     ),
                 ),
                 setOf("key1", "key2", "key3", "key4"),
             ),
             arrayOf(
-                ColorTokenResult.TokenData(
+                GradientTokenResult.ComposeTokenData(
                     light = emptyMap(),
                     dark = mapOf(
-                        "key3" to "value3",
-                        "key4" to "value4",
+                        "key3" to getParams("value3"),
+                        "key4" to getParams("value4"),
                     ),
                 ),
                 setOf("key3", "key4"),
             ),
             arrayOf(
-                ColorTokenResult.TokenData(
+                GradientTokenResult.ComposeTokenData(
                     light = emptyMap(),
                     dark = emptyMap(),
                 ),

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeScreenClassesTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeScreenClassesTest.kt
@@ -14,7 +14,7 @@ internal class MergeScreenClassesTest(
 ) {
 
     @Test
-    fun `mergedLightAndDark() должна возвращать объединение ключей словарей темной и светлой темы`() {
+    fun `mergedScreenClasses() должна возвращать объединение ключей словарей темной и светлой темы`() {
         Assert.assertEquals(expectedResultSet, tokenData.mergedScreenClasses())
     }
 

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeScreenClassesTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/MergeScreenClassesTest.kt
@@ -1,0 +1,81 @@
+package com.sdds.plugin.themebuilder.internal.attributes.generator
+
+import com.sdds.plugin.themebuilder.internal.generator.data.TypographyTokenResult
+import com.sdds.plugin.themebuilder.internal.generator.data.mergedScreenClasses
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class MergeScreenClassesTest(
+    private val tokenData: TypographyTokenResult.ComposeTokenData,
+    private val expectedResultSet: Set<String>,
+) {
+
+    @Test
+    fun `mergedLightAndDark() должна возвращать объединение ключей словарей темной и светлой темы`() {
+        Assert.assertEquals(expectedResultSet, tokenData.mergedScreenClasses())
+    }
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data() = listOf(
+            arrayOf(
+                TypographyTokenResult.ComposeTokenData(
+                    small = mapOf(
+                        "key1" to "value1",
+                        "key2" to "value2",
+                    ),
+                    medium = mapOf(
+                        "key1" to "value1",
+                        "key2" to "value2",
+                    ),
+                    large = mapOf(
+                        "key1" to "value1",
+                        "key2" to "value2",
+                    ),
+                ),
+                setOf("key1", "key2"),
+            ),
+            arrayOf(
+                TypographyTokenResult.ComposeTokenData(
+                    small = mapOf(
+                        "key1" to "value1",
+                        "key2" to "value2",
+                    ),
+                    medium = mapOf(
+                        "key3" to "value3",
+                        "key4" to "value4",
+                    ),
+                    large = mapOf(
+                        "key5" to "value5",
+                        "key6" to "value6",
+                    ),
+                ),
+                setOf("key1", "key2", "key3", "key4", "key5", "key6"),
+            ),
+            arrayOf(
+                TypographyTokenResult.ComposeTokenData(
+                    small = emptyMap(),
+                    medium = emptyMap(),
+                    large = mapOf(
+                        "key3" to "value3",
+                        "key4" to "value4",
+                    ),
+                ),
+                setOf("key3", "key4"),
+            ),
+            arrayOf(
+                TypographyTokenResult.ComposeTokenData(
+                    small = emptyMap(),
+                    medium = emptyMap(),
+                    large = emptyMap(),
+                ),
+                emptySet<String>(),
+            ),
+        )
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/ViewTypographyAttributeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/attributes/generator/ViewTypographyAttributeGeneratorTest.kt
@@ -66,14 +66,10 @@ class ViewTypographyAttributeGeneratorTest {
     }
 
     private companion object {
-        val typographyAttrs = listOf(
-            TypographyTokenResult.ViewTokenData(
-                attrName = "typographyDisplayLNormal",
-                tokenRefName = "@style/Thmbldr.Typography.DisplayLNormal",
-            ),
-            TypographyTokenResult.ViewTokenData(
-                attrName = "typographyHeaderH3Bold",
-                tokenRefName = "@style/Thmbldr.Typography.HeaderH3Bold",
+        val typographyAttrs = TypographyTokenResult.ViewTokenData(
+            mapOf(
+                "typographyDisplayLNormal" to "@style/Thmbldr.Typography.DisplayLNormal",
+                "typographyHeaderH3Bold" to "@style/Thmbldr.Typography.HeaderH3Bold",
             ),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/DimenTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/DimenTokenGeneratorTest.kt
@@ -20,21 +20,21 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 
 /**
- * Unit тесты [DimenGenerator]
+ * Unit тесты [DimenTokenGenerator]
  * @author Малышев Александр on 13.03.2024
  */
-class DimenGeneratorTest {
+class DimenTokenGeneratorTest {
 
     private lateinit var mockOutputResDir: File
     private lateinit var mockDimensAggregator: DimensAggregator
-    private lateinit var underTest: DimenGenerator
+    private lateinit var underTest: DimenTokenGenerator
 
     @Before
     fun setUp() {
         mockkObject(FileProvider)
         mockOutputResDir = mockk(relaxed = true)
         mockDimensAggregator = mockk(relaxed = true)
-        underTest = DimenGenerator(
+        underTest = DimenTokenGenerator(
             outputResDir = mockOutputResDir,
             dimensAggregator = mockDimensAggregator,
             xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr"),

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/FontTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/FontTokenGeneratorTest.kt
@@ -31,15 +31,15 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 
 /**
- * Unit тесты [FontGenerator]
+ * Unit тесты [FontTokenGenerator]
  */
-class FontGeneratorTest {
+class FontTokenGeneratorTest {
     private lateinit var outputKt: ByteArrayOutputStream
     private lateinit var mockOutputResDir: File
     private lateinit var mockDownloaderFactory: FontDownloaderFactory
     private lateinit var mockFileDownloader: FileDownloader
     private lateinit var fontDownloader: FontDownloader
-    private lateinit var underTest: FontGenerator
+    private lateinit var underTest: FontTokenGenerator
 
     @Before
     fun setUp() {
@@ -55,7 +55,7 @@ class FontGeneratorTest {
         mockDownloaderFactory = mockk<FontDownloaderFactory>(relaxed = true)
         every { mockDownloaderFactory.create() } returns fontDownloader
 
-        underTest = FontGenerator(
+        underTest = FontTokenGenerator(
             outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
             outputResDir = mockOutputResDir,
             target = ThemeBuilderTarget.ALL,

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/GradientTokenGeneratorTest.kt
@@ -31,14 +31,14 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 
 /**
- * Unit тесты [GradientGenerator]
+ * Unit тесты [GradientTokenGenerator]
  * @author Малышев Александр on 13.03.2024
  */
-class GradientGeneratorTest {
+class GradientTokenGeneratorTest {
 
     private lateinit var outputKt: ByteArrayOutputStream
     private lateinit var mockOutputResDir: File
-    private lateinit var underTest: GradientGenerator
+    private lateinit var underTest: GradientTokenGenerator
 
     @Before
     fun setUp() {
@@ -49,7 +49,7 @@ class GradientGeneratorTest {
         )
         outputKt = ByteArrayOutputStream()
         mockOutputResDir = mockk(relaxed = true)
-        underTest = GradientGenerator(
+        underTest = GradientTokenGenerator(
             outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
             outputResDir = mockOutputResDir,
             target = ThemeBuilderTarget.ALL,

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/ShadowTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/ShadowTokenGeneratorTest.kt
@@ -6,12 +6,11 @@ import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.XmlResourcesDocumentBuilderFactory
 import com.sdds.plugin.themebuilder.internal.serializer.Serializer
-import com.sdds.plugin.themebuilder.internal.token.RoundedShapeTokenValue
-import com.sdds.plugin.themebuilder.internal.token.ShapeToken
+import com.sdds.plugin.themebuilder.internal.token.ShadowToken
+import com.sdds.plugin.themebuilder.internal.token.ShadowTokenValue
 import com.sdds.plugin.themebuilder.internal.utils.FileProvider
 import com.sdds.plugin.themebuilder.internal.utils.FileProvider.fileWriter
-import com.sdds.plugin.themebuilder.internal.utils.FileProvider.shapesXmlFile
-import com.sdds.plugin.themebuilder.internal.utils.ResourceReferenceProvider
+import com.sdds.plugin.themebuilder.internal.utils.FileProvider.shadowsXmlFile
 import com.sdds.plugin.themebuilder.internal.utils.getResourceAsText
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
@@ -29,15 +28,15 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 
 /**
- * Unit тесты [ShapeGenerator]
+ * Unit тесты [ShadowTokenGenerator]
  * @author Малышев Александр on 13.03.2024
  */
-class ShapeGeneratorTest {
+class ShadowTokenGeneratorTest {
 
     private lateinit var outputKt: ByteArrayOutputStream
     private lateinit var mockOutputResDir: File
     private lateinit var mockDimenAggregator: DimensAggregator
-    private lateinit var underTest: ShapeGenerator
+    private lateinit var underTest: ShadowTokenGenerator
 
     @Before
     fun setUp() {
@@ -49,15 +48,13 @@ class ShapeGeneratorTest {
         outputKt = ByteArrayOutputStream()
         mockOutputResDir = mockk(relaxed = true)
         mockDimenAggregator = mockk(relaxed = true)
-        underTest = ShapeGenerator(
+        underTest = ShadowTokenGenerator(
             outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
             outputResDir = mockOutputResDir,
             target = ThemeBuilderTarget.ALL,
             xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr"),
             ktFileBuilderFactory = KtFileBuilderFactory("com.test"),
-            dimensAggregator = mockDimenAggregator,
-            resourceReferenceProvider = ResourceReferenceProvider("thmbldr"),
-            shapeTokenValues = shapeTokenValues,
+            shadowTokenValues = shadowTokenValues,
         )
     }
 
@@ -72,26 +69,28 @@ class ShapeGeneratorTest {
     }
 
     @Test
-    fun `ShapeGenerator добавляет токен и генерирует файлы для compose и view system`() {
-        val input = getResourceAsText("inputs/test-shape-input.json")
-        val shapeTokens = Serializer.meta.decodeFromString<List<ShapeToken>>(input)
+    fun `ShadowGenerator добавляет токен и генерирует файлы для compose и view system`() {
+        val input = getResourceAsText("inputs/test-shadow-input.json")
+        val shadowToken = Serializer.meta.decodeFromString<ShadowToken>(input)
         val outputXml = ByteArrayOutputStream()
-        val shapesXmlFile = mockk<File>(relaxed = true)
-        every { shapesXmlFile.fileWriter() } returns outputXml.writer()
-        every { mockOutputResDir.shapesXmlFile() } returns shapesXmlFile
+        val shadowsXmlFile = mockk<File>(relaxed = true)
+        every { shadowsXmlFile.fileWriter() } returns outputXml.writer()
+        every { mockOutputResDir.shadowsXmlFile() } returns shadowsXmlFile
 
-        shapeTokens.forEach { underTest.addToken(it) }
+        underTest.addToken(shadowToken)
         underTest.generate()
 
-        assertEquals(getResourceAsText("shape-outputs/test-shape-output.xml"), outputXml.toString())
-        assertEquals(getResourceAsText("shape-outputs/TestShapeOutputKt.txt"), outputKt.toString())
+        assertEquals(
+            getResourceAsText("shadow-outputs/test-shadow-output.xml"),
+            outputXml.toString(),
+        )
+        assertEquals(
+            getResourceAsText("shadow-outputs/TestShadowOutputKt.txt"),
+            outputKt.toString(),
+        )
     }
 
     private companion object {
-        val shapeTokenValues = mapOf(
-            "round.xs" to RoundedShapeTokenValue(cornerRadius = 6.0f),
-            "round.s" to RoundedShapeTokenValue(cornerRadius = 8.0f),
-            "round.l" to RoundedShapeTokenValue(cornerRadius = 16.0f),
-        )
+        val shadowTokenValues = mapOf("down.hard.l" to ShadowTokenValue("#99000000", 1.0f))
     }
 }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGeneratorTest.kt
@@ -30,15 +30,15 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 
 /**
- * Unit тесты [TypographyGenerator]
+ * Unit тесты [TypographyTokenGenerator]
  * @author Малышев Александр on 13.03.2024
  */
-class TypographyGeneratorTest {
+class TypographyTokenGeneratorTest {
 
     private lateinit var outputKt: ByteArrayOutputStream
     private lateinit var mockOutputResDir: File
     private lateinit var mockDimensAggregator: DimensAggregator
-    private lateinit var underTest: TypographyGenerator
+    private lateinit var underTest: TypographyTokenGenerator
 
     @Before
     fun setUp() {
@@ -50,7 +50,7 @@ class TypographyGeneratorTest {
         outputKt = ByteArrayOutputStream()
         mockOutputResDir = mockk(relaxed = true)
         mockDimensAggregator = mockk(relaxed = true)
-        underTest = TypographyGenerator(
+        underTest = TypographyTokenGenerator(
             outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
             outputResDir = mockOutputResDir,
             target = ThemeBuilderTarget.ALL,
@@ -122,7 +122,7 @@ class TypographyGeneratorTest {
 
     private companion object {
         val typographyTokenValues = mapOf(
-            "screen-l.display.l" to TypographyTokenValue(
+            "screen-l.display.l.normal" to TypographyTokenValue(
                 fontFamilyRef = "sans",
                 fontWeight = 300,
                 fontStyle = "normal",
@@ -130,7 +130,31 @@ class TypographyGeneratorTest {
                 letterSpacing = 0.02f,
                 lineHeight = 128f,
             ),
-            "screen-m.display.l" to TypographyTokenValue(
+            "screen-l.display.l.bold" to TypographyTokenValue(
+                fontFamilyRef = "sans",
+                fontWeight = 300,
+                fontStyle = "normal",
+                textSize = 128f,
+                letterSpacing = 0.02f,
+                lineHeight = 128f,
+            ),
+            "screen-s.text.l.normal" to TypographyTokenValue(
+                fontFamilyRef = "sans",
+                fontWeight = 400,
+                fontStyle = "normal",
+                textSize = 124f,
+                letterSpacing = 0.04f,
+                lineHeight = 124f,
+            ),
+            "screen-m.header.l.normal" to TypographyTokenValue(
+                fontFamilyRef = "sans",
+                fontWeight = 400,
+                fontStyle = "normal",
+                textSize = 124f,
+                letterSpacing = 0.04f,
+                lineHeight = 124f,
+            ),
+            "screen-m.display.l.normal" to TypographyTokenValue(
                 fontFamilyRef = "sans",
                 fontWeight = 300,
                 fontStyle = "normal",
@@ -138,7 +162,7 @@ class TypographyGeneratorTest {
                 letterSpacing = 0.02f,
                 lineHeight = 96f,
             ),
-            "screen-s.display.l" to TypographyTokenValue(
+            "screen-s.display.l.normal" to TypographyTokenValue(
                 fontFamilyRef = "sans",
                 fontWeight = 300,
                 fontStyle = "normal",

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ComposeThemeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ComposeThemeGeneratorTest.kt
@@ -71,7 +71,13 @@ class ComposeThemeGeneratorTest {
             themeName = "Test",
         )
         underTest.setColorTokenData(ColorTokenResult.TokenData(emptyMap(), emptyMap()))
-        underTest.setTypographyTokenData(emptyList())
+        underTest.setTypographyTokenData(
+            TypographyTokenResult.ComposeTokenData(
+                emptyMap(),
+                emptyMap(),
+                emptyMap(),
+            ),
+        )
         underTest.generate()
 
         Assert.assertEquals(
@@ -92,17 +98,13 @@ class ComposeThemeGeneratorTest {
             ),
         )
 
-        val typographyAttrs = listOf(
-            TypographyTokenResult.ComposeTokenData(
-                attrName = "bodyMNormal",
-                tokenRefName = "BodyMNormal",
-                screen = TypographyTokenResult.ComposeTokenData.Screen.MEDIUM,
+        val typographyAttrs = TypographyTokenResult.ComposeTokenData(
+            small = emptyMap(),
+            medium = mapOf(
+                "headerH3Bold" to "TypographyMediumTokens.HeaderH3Bold",
+                "bodyMNormal" to "TypographyMediumTokens.BodyMNormal",
             ),
-            TypographyTokenResult.ComposeTokenData(
-                attrName = "headerH3Bold",
-                tokenRefName = "HeaderH3Bold",
-                screen = TypographyTokenResult.ComposeTokenData.Screen.MEDIUM,
-            ),
+            large = emptyMap(),
         )
     }
 }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
@@ -105,14 +105,10 @@ class ViewThemeGeneratorTest {
             ),
         )
 
-        val typographyAttrs = listOf(
-            TypographyTokenResult.ViewTokenData(
-                attrName = "typographyDisplayLNormal",
-                tokenRefName = "@style/Thmbldr.Typography.DisplayLNormal",
-            ),
-            TypographyTokenResult.ViewTokenData(
-                attrName = "typographyHeaderH3Bold",
-                tokenRefName = "@style/Thmbldr.Typography.HeaderH3Bold",
+        val typographyAttrs = TypographyTokenResult.ViewTokenData(
+            mapOf(
+                "typographyDisplayLNormal" to "@style/Thmbldr.Typography.DisplayLNormal",
+                "typographyHeaderH3Bold" to "@style/Thmbldr.Typography.HeaderH3Bold",
             ),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt.txt
@@ -136,7 +136,7 @@ public fun largeThemeTypography(): ThemeTypography = ThemeTypography(displayLNor
 @Composable
 public fun dynamicThemeTypography(): ThemeTypography = when
         (collectWindowSizeInfoAsState().value.widthClass) {
-    WindowSizeClass.Expanded -> smallThemeTypography()
+    WindowSizeClass.Expanded -> largeThemeTypography()
     WindowSizeClass.Medium -> mediumThemeTypography()
     WindowSizeClass.Compact -> smallThemeTypography()
 }

--- a/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_1.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_1.txt
@@ -103,6 +103,7 @@ import kotlin.Unit
 @Immutable
 public data class ThemeTypography internal constructor(
     public val displayLNormal: TextStyle,
+    public val displayLBold: TextStyle,
 )
 
 internal val LocalThemeTypography: ProvidableCompositionLocal<ThemeTypography> =
@@ -115,19 +116,19 @@ private val LocalThemeTextStyle: ProvidableCompositionLocal<TextStyle> =
  * Возвращает [ThemeTypography] для ширины окна до 600dp
  */
 public fun smallThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
-        TypographySmallTokens.DisplayLNormal)
+        TypographySmallTokens.DisplayLNormal, displayLBold = TypographySmallTokens.DisplayLBold)
 
 /**
  * Возвращает [ThemeTypography] для ширины окна от 600dp до 840dp
  */
 public fun mediumThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
-        TypographyMediumTokens.DisplayLNormal)
+        TypographyMediumTokens.DisplayLNormal, displayLBold = TypographyMediumTokens.DisplayLBold)
 
 /**
  * Возвращает [ThemeTypography] для ширины окна от 840dp
  */
 public fun largeThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
-        TypographyLargeTokens.DisplayLNormal)
+        TypographyLargeTokens.DisplayLNormal, displayLBold = TypographyLargeTokens.DisplayLBold)
 
 /**
  * Возвращает разные [ThemeTypography] в зависимости от ширины окна. Значение динамически изменяется

--- a/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_2.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_2.txt
@@ -1,0 +1,149 @@
+package com.sdds.playground.themebuilder.tokens
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+/**
+ * Класс размерности окна.
+ * См. [developer.android.com](https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes)
+ */
+enum class WindowSizeClass {
+    Compact,
+    Medium,
+    Expanded,
+}
+
+/**
+ * Возвращает значение в dp - брейкпоинт по ширине для указанного класса размерности.
+ */
+fun WindowSizeClass.widthBreakPoint(): Dp =
+    when (this) {
+        WindowSizeClass.Compact -> 0.dp
+        WindowSizeClass.Medium -> 600.dp
+        WindowSizeClass.Expanded -> 840.dp
+    }
+
+/**
+ * Возвращает значение в dp - брейкпоинт по высоте для указанного класса размерности.
+ */
+fun WindowSizeClass.heightBreakPoint(): Dp =
+    when (this) {
+        WindowSizeClass.Compact -> 0.dp
+        WindowSizeClass.Medium -> 480.dp
+        WindowSizeClass.Expanded -> 900.dp
+    }
+
+/**
+ * Информация о размерности окна
+ * @property widthClass класс размерности ширины окна
+ * @property heightClass класс размерности высоты окна
+ */
+data class WindowSizeInfo(
+    val widthClass: WindowSizeClass = WindowSizeClass.Medium,
+    val heightClass: WindowSizeClass = WindowSizeClass.Medium,
+)
+
+/**
+ * Возвращает информацию о размерности окна как state
+ */
+@Composable
+fun collectWindowSizeInfoAsState(): State<WindowSizeInfo> {
+    val info = remember { mutableStateOf(WindowSizeInfo()) }
+    val context = LocalContext.current
+    val mediumWidthBreakPoint = WindowSizeClass.Medium.widthBreakPoint().px
+    val mediumHeightBreakPoint = WindowSizeClass.Medium.heightBreakPoint().px
+    val expandedWidthBreakPoint = WindowSizeClass.Expanded.widthBreakPoint().px
+    val expandedHeightBreakPoint = WindowSizeClass.Expanded.heightBreakPoint().px
+
+    info.value = remember(context, LocalConfiguration.current) {
+        val displayMetrics = context.resources.displayMetrics
+        val size = IntSize(displayMetrics.widthPixels, displayMetrics.heightPixels)
+        val widthClass = when {
+            size.width < mediumWidthBreakPoint -> WindowSizeClass.Compact
+            size.width in mediumWidthBreakPoint until expandedWidthBreakPoint -> WindowSizeClass.Medium
+            else -> WindowSizeClass.Expanded
+        }
+        val heightClass = when {
+            size.height < mediumHeightBreakPoint -> WindowSizeClass.Compact
+            size.height in mediumHeightBreakPoint until expandedHeightBreakPoint -> WindowSizeClass.Medium
+            else -> WindowSizeClass.Expanded
+        }
+        WindowSizeInfo(widthClass, heightClass)
+    }
+
+    return info
+}
+
+private val Dp.px: Int
+    @Composable
+    get() = with(LocalDensity.current) { this@px.roundToPx() }
+package com.sdds.playground.themebuilder.tokens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.text.TextStyle
+import com.sdds.playground.themebuilder.tokens.ThemeTypography
+import kotlin.Unit
+
+/**
+ * Типографика Theme
+ */
+@Immutable
+public data class ThemeTypography internal constructor(
+    public val displayLNormal: TextStyle,
+    public val displayLBold: TextStyle,
+)
+
+internal val LocalThemeTypography: ProvidableCompositionLocal<ThemeTypography> =
+        staticCompositionLocalOf { mediumThemeTypography() }
+
+private val LocalThemeTextStyle: ProvidableCompositionLocal<TextStyle> =
+        compositionLocalOf(structuralEqualityPolicy()) { TextStyle.Default }
+
+/**
+ * Возвращает [ThemeTypography] для ширины окна до 600dp
+ */
+public fun smallThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
+        TypographySmallTokens.DisplayLNormal, displayLBold = TypographyMediumTokens.DisplayLBold)
+
+/**
+ * Возвращает [ThemeTypography] для ширины окна от 600dp до 840dp
+ */
+public fun mediumThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
+        TypographySmallTokens.DisplayLNormal, displayLBold = TypographyMediumTokens.DisplayLBold)
+
+/**
+ * Возвращает [ThemeTypography] для ширины окна от 840dp
+ */
+public fun largeThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
+        TypographyLargeTokens.DisplayLNormal, displayLBold = TypographyMediumTokens.DisplayLBold)
+
+/**
+ * Возвращает разные [ThemeTypography] в зависимости от ширины окна. Значение динамически изменяется
+ * при изменении ширины окна.
+ */
+@Composable
+public fun dynamicThemeTypography(): ThemeTypography = when
+        (collectWindowSizeInfoAsState().value.widthClass) {
+    WindowSizeClass.Expanded -> largeThemeTypography()
+    WindowSizeClass.Medium -> mediumThemeTypography()
+    WindowSizeClass.Compact -> smallThemeTypography()
+}
+
+@Composable
+internal fun ProvideTextStyle(`value`: TextStyle, content: @Composable () -> Unit): Unit {
+    val mergedStyle = LocalThemeTextStyle.current.merge(value)
+    CompositionLocalProvider(LocalThemeTextStyle provides mergedStyle, content = content)
+}

--- a/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_3.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_3.txt
@@ -1,0 +1,149 @@
+package com.sdds.playground.themebuilder.tokens
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+/**
+ * Класс размерности окна.
+ * См. [developer.android.com](https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes)
+ */
+enum class WindowSizeClass {
+    Compact,
+    Medium,
+    Expanded,
+}
+
+/**
+ * Возвращает значение в dp - брейкпоинт по ширине для указанного класса размерности.
+ */
+fun WindowSizeClass.widthBreakPoint(): Dp =
+    when (this) {
+        WindowSizeClass.Compact -> 0.dp
+        WindowSizeClass.Medium -> 600.dp
+        WindowSizeClass.Expanded -> 840.dp
+    }
+
+/**
+ * Возвращает значение в dp - брейкпоинт по высоте для указанного класса размерности.
+ */
+fun WindowSizeClass.heightBreakPoint(): Dp =
+    when (this) {
+        WindowSizeClass.Compact -> 0.dp
+        WindowSizeClass.Medium -> 480.dp
+        WindowSizeClass.Expanded -> 900.dp
+    }
+
+/**
+ * Информация о размерности окна
+ * @property widthClass класс размерности ширины окна
+ * @property heightClass класс размерности высоты окна
+ */
+data class WindowSizeInfo(
+    val widthClass: WindowSizeClass = WindowSizeClass.Medium,
+    val heightClass: WindowSizeClass = WindowSizeClass.Medium,
+)
+
+/**
+ * Возвращает информацию о размерности окна как state
+ */
+@Composable
+fun collectWindowSizeInfoAsState(): State<WindowSizeInfo> {
+    val info = remember { mutableStateOf(WindowSizeInfo()) }
+    val context = LocalContext.current
+    val mediumWidthBreakPoint = WindowSizeClass.Medium.widthBreakPoint().px
+    val mediumHeightBreakPoint = WindowSizeClass.Medium.heightBreakPoint().px
+    val expandedWidthBreakPoint = WindowSizeClass.Expanded.widthBreakPoint().px
+    val expandedHeightBreakPoint = WindowSizeClass.Expanded.heightBreakPoint().px
+
+    info.value = remember(context, LocalConfiguration.current) {
+        val displayMetrics = context.resources.displayMetrics
+        val size = IntSize(displayMetrics.widthPixels, displayMetrics.heightPixels)
+        val widthClass = when {
+            size.width < mediumWidthBreakPoint -> WindowSizeClass.Compact
+            size.width in mediumWidthBreakPoint until expandedWidthBreakPoint -> WindowSizeClass.Medium
+            else -> WindowSizeClass.Expanded
+        }
+        val heightClass = when {
+            size.height < mediumHeightBreakPoint -> WindowSizeClass.Compact
+            size.height in mediumHeightBreakPoint until expandedHeightBreakPoint -> WindowSizeClass.Medium
+            else -> WindowSizeClass.Expanded
+        }
+        WindowSizeInfo(widthClass, heightClass)
+    }
+
+    return info
+}
+
+private val Dp.px: Int
+    @Composable
+    get() = with(LocalDensity.current) { this@px.roundToPx() }
+package com.sdds.playground.themebuilder.tokens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.text.TextStyle
+import com.sdds.playground.themebuilder.tokens.ThemeTypography
+import kotlin.Unit
+
+/**
+ * Типографика Theme
+ */
+@Immutable
+public data class ThemeTypography internal constructor(
+    public val displayLNormal: TextStyle,
+    public val displayLBold: TextStyle,
+)
+
+internal val LocalThemeTypography: ProvidableCompositionLocal<ThemeTypography> =
+        staticCompositionLocalOf { mediumThemeTypography() }
+
+private val LocalThemeTextStyle: ProvidableCompositionLocal<TextStyle> =
+        compositionLocalOf(structuralEqualityPolicy()) { TextStyle.Default }
+
+/**
+ * Возвращает [ThemeTypography] для ширины окна до 600dp
+ */
+public fun smallThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
+        TypographyLargeTokens.DisplayLNormal, displayLBold = TypographyLargeTokens.DisplayLBold)
+
+/**
+ * Возвращает [ThemeTypography] для ширины окна от 600dp до 840dp
+ */
+public fun mediumThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
+        TypographyLargeTokens.DisplayLNormal, displayLBold = TypographyLargeTokens.DisplayLBold)
+
+/**
+ * Возвращает [ThemeTypography] для ширины окна от 840dp
+ */
+public fun largeThemeTypography(): ThemeTypography = ThemeTypography(displayLNormal =
+        TypographyLargeTokens.DisplayLNormal, displayLBold = TypographyLargeTokens.DisplayLBold)
+
+/**
+ * Возвращает разные [ThemeTypography] в зависимости от ширины окна. Значение динамически изменяется
+ * при изменении ширины окна.
+ */
+@Composable
+public fun dynamicThemeTypography(): ThemeTypography = when
+        (collectWindowSizeInfoAsState().value.widthClass) {
+    WindowSizeClass.Expanded -> largeThemeTypography()
+    WindowSizeClass.Medium -> mediumThemeTypography()
+    WindowSizeClass.Compact -> smallThemeTypography()
+}
+
+@Composable
+internal fun ProvideTextStyle(`value`: TextStyle, content: @Composable () -> Unit): Unit {
+    val mergedStyle = LocalThemeTextStyle.current.merge(value)
+    CompositionLocalProvider(LocalThemeTextStyle provides mergedStyle, content = content)
+}

--- a/sdds-core/plugin_theme_builder/src/test/resources/inputs/test-typography-input.json
+++ b/sdds-core/plugin_theme_builder/src/test/resources/inputs/test-typography-input.json
@@ -1,7 +1,7 @@
 [
   {
     "displayName": "displayL",
-    "name": "screen-l.display.l",
+    "name": "screen-l.display.l.normal",
     "tags": [
       "screen-l",
       "display",
@@ -13,7 +13,43 @@
   },
   {
     "displayName": "displayL",
-    "name": "screen-m.display.l",
+    "name": "screen-l.display.l.bold",
+    "tags": [
+      "screen-l",
+      "display",
+      "l"
+    ],
+    "type": "typography",
+    "description": "шрифт android",
+    "enabled": true
+  },
+  {
+    "displayName": "textL",
+    "name": "screen-s.text.l.normal",
+    "tags": [
+      "screen-s",
+      "text",
+      "l"
+    ],
+    "type": "typography",
+    "description": "шрифт android",
+    "enabled": true
+  },
+  {
+    "displayName": "headerL",
+    "name": "screen-m.header.l.normal",
+    "tags": [
+      "screen-m",
+      "header",
+      "l"
+    ],
+    "type": "typography",
+    "description": "шрифт android",
+    "enabled": true
+  },
+  {
+    "displayName": "displayL",
+    "name": "screen-m.display.l.normal",
     "tags": [
       "screen-m",
       "display",
@@ -25,7 +61,7 @@
   },
   {
     "displayName": "displayL",
-    "name": "screen-s.display.l",
+    "name": "screen-s.display.l.normal",
     "tags": [
       "screen-s",
       "display",

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/TestTypographyOutputKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/TestTypographyOutputKt.txt
@@ -8,23 +8,21 @@ public object TypographyLargeTokens {
     /**
      * шрифт android
      */
-    public val DisplayL: TextStyle = TextStyle(
+    public val DisplayLNormal: TextStyle = TextStyle(
                 fontWeight = FontWeight(300),
                 fontSize = 128.0.sp,
                 lineHeight = 128.0.sp,
                 letterSpacing = 0.02.sp,
                 fontFamily = FontTokens.sans,
             )
-}
 
-public object TypographyMediumTokens {
     /**
      * шрифт android
      */
-    public val DisplayL: TextStyle = TextStyle(
+    public val DisplayLBold: TextStyle = TextStyle(
                 fontWeight = FontWeight(300),
-                fontSize = 96.0.sp,
-                lineHeight = 96.0.sp,
+                fontSize = 128.0.sp,
+                lineHeight = 128.0.sp,
                 letterSpacing = 0.02.sp,
                 fontFamily = FontTokens.sans,
             )
@@ -34,10 +32,45 @@ public object TypographySmallTokens {
     /**
      * шрифт android
      */
-    public val DisplayL: TextStyle = TextStyle(
+    public val TextLNormal: TextStyle = TextStyle(
+                fontWeight = FontWeight(400),
+                fontSize = 124.0.sp,
+                lineHeight = 124.0.sp,
+                letterSpacing = 0.04.sp,
+                fontFamily = FontTokens.sans,
+            )
+
+    /**
+     * шрифт android
+     */
+    public val DisplayLNormal: TextStyle = TextStyle(
                 fontWeight = FontWeight(300),
                 fontSize = 72.0.sp,
                 lineHeight = 72.0.sp,
+                letterSpacing = 0.02.sp,
+                fontFamily = FontTokens.sans,
+            )
+}
+
+public object TypographyMediumTokens {
+    /**
+     * шрифт android
+     */
+    public val HeaderLNormal: TextStyle = TextStyle(
+                fontWeight = FontWeight(400),
+                fontSize = 124.0.sp,
+                lineHeight = 124.0.sp,
+                letterSpacing = 0.04.sp,
+                fontFamily = FontTokens.sans,
+            )
+
+    /**
+     * шрифт android
+     */
+    public val DisplayLNormal: TextStyle = TextStyle(
+                fontWeight = FontWeight(300),
+                fontSize = 96.0.sp,
+                lineHeight = 96.0.sp,
                 letterSpacing = 0.02.sp,
                 fontFamily = FontTokens.sans,
             )

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-large-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-large-output.xml
@@ -1,12 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!--шрифт android-->
-    <style name="Thmbldr.TextAppearance.DisplayL">
+    <style name="Thmbldr.TextAppearance.TextLNormal">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">400</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_s_text_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_s_text_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.DisplayLNormal">
         <item name="fontFamily">@font/thmbldr_sans</item>
         <item name="fontWeight">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
-        <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_text_size</item>
-        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_l_display_l_line_height</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_l_display_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.HeaderLNormal">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">400</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_m_header_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_m_header_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.DisplayLBold">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">300</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.02</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_bold_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_l_display_l_bold_line_height</item>
     </style>
 </resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-output.xml
@@ -2,12 +2,39 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Thmbldr.TextAppearance"/>
     <!--шрифт android-->
-    <style name="Thmbldr.TextAppearance.DisplayL">
+    <style name="Thmbldr.TextAppearance.TextLNormal">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">400</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_s_text_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_s_text_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.DisplayLNormal">
         <item name="fontFamily">@font/thmbldr_sans</item>
         <item name="fontWeight">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
-        <item name="android:textSize">@dimen/thmbldr_screen_m_display_l_text_size</item>
-        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_m_display_l_line_height</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_m_display_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_m_display_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.HeaderLNormal">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">400</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_m_header_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_m_header_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.DisplayLBold">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">300</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.02</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_bold_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_l_display_l_bold_line_height</item>
     </style>
 </resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-small-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-small-output.xml
@@ -1,12 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!--шрифт android-->
-    <style name="Thmbldr.TextAppearance.DisplayL">
+    <style name="Thmbldr.TextAppearance.TextLNormal">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">400</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_s_text_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_s_text_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.DisplayLNormal">
         <item name="fontFamily">@font/thmbldr_sans</item>
         <item name="fontWeight">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
-        <item name="android:textSize">@dimen/thmbldr_screen_s_display_l_text_size</item>
-        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_s_display_l_line_height</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_s_display_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_s_display_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.HeaderLNormal">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">400</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_m_header_l_normal_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_m_header_l_normal_line_height</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.TextAppearance.DisplayLBold">
+        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontWeight">300</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:letterSpacing">0.02</item>
+        <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_bold_text_size</item>
+        <item name="android:lineHeight" tools:targetApi="p">@dimen/thmbldr_screen_l_display_l_bold_line_height</item>
     </style>
 </resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-typography-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-typography-output.xml
@@ -2,7 +2,19 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Thmbldr.Typography"/>
     <!--шрифт android-->
-    <style name="Thmbldr.Typography.DisplayL">
-        <item name="android:textAppearance">@style/Thmbldr.TextAppearance.DisplayL</item>
+    <style name="Thmbldr.Typography.TextLNormal">
+        <item name="android:textAppearance">@style/Thmbldr.TextAppearance.TextLNormal</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.Typography.DisplayLNormal">
+        <item name="android:textAppearance">@style/Thmbldr.TextAppearance.DisplayLNormal</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.Typography.HeaderLNormal">
+        <item name="android:textAppearance">@style/Thmbldr.TextAppearance.HeaderLNormal</item>
+    </style>
+    <!--шрифт android-->
+    <style name="Thmbldr.Typography.DisplayLBold">
+        <item name="android:textAppearance">@style/Thmbldr.TextAppearance.DisplayLBold</item>
     </style>
 </resources>


### PR DESCRIPTION
* Поддержал целостность токенов типографики. 

Для этого пришлось вмешаться в процесс генерации токенов типографики для вью - сначала токены агрегируются в словари для разных типов экранов и уже в функции generate() xml файлы наполняются нужными данными.
Для Compose все происходит по аналогии с цветами и градиентами - на уровне генерации атрибутов.