### PR TITLE
fix(sdds-acore/theme-builder): Add leading zero to hex alpha

### DIFF
--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorResolver.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorResolver.kt
@@ -108,8 +108,11 @@ internal object ColorResolver {
         return (0xFF * this.toFloat())
             .toInt()
             .toString(16)
+            .appendLeadingZeroIfNeed()
             .toUpperCase(Locale.getDefault())
     }
+
+    private fun String.appendLeadingZeroIfNeed() = if (this.length == 1) "0$this" else this
 
     /**
      * Преобразует строку цвета из формата RGBA или RGB в формат ARGB

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorResolverTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/ColorResolverTest.kt
@@ -61,6 +61,18 @@ class ColorResolverTest {
             "#19AAAAAA",
             resolveColor("[general.green.100][0.1]", "tokenName", palette, HexFormat.XML_HEX),
         )
+        assertEquals(
+            "#05AAAAAA",
+            resolveColor("[general.green.100][0.02]", "tokenName", palette, HexFormat.XML_HEX),
+        )
+        assertEquals(
+            "#00AAAAAA",
+            resolveColor("[general.green.100][0.0]", "tokenName", palette, HexFormat.XML_HEX),
+        )
+        assertEquals(
+            "#00AAAAAA",
+            resolveColor("[general.green.100][0]", "tokenName", palette, HexFormat.XML_HEX),
+        )
     }
 
     private companion object {


### PR DESCRIPTION
* Исправил хекс, когда в палитре указана альфа, которая при переводе в хекс имеет один знак. Добавляю 0 в этом случае.