### PR TITLE
feat(sdds-acore/theme-builder): Improve compose typography tokens with lineHeight support

### DIFF
--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/builder/KtFileBuilder.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/builder/KtFileBuilder.kt
@@ -487,6 +487,8 @@ internal class KtFileBuilder(
         val TypeFontWeight = ClassName("androidx.compose.ui.text.font", "FontWeight")
         val TypeFontStyle = ClassName("androidx.compose.ui.text.font", "FontStyle")
         val TypeFontFamily = ClassName("androidx.compose.ui.text.font", "FontFamily")
+        val TypeLineHeightStyle = ClassName("androidx.compose.ui.text.style", "LineHeightStyle")
+        val TypePlatformTextStyle = ClassName("androidx.compose.ui.text", "PlatformTextStyle")
         val TypeSp = ClassName("androidx.compose.ui.unit", "sp")
         val TypeDp = ClassName("androidx.compose.ui.unit", "Dp")
         val TypeDpExtension = ClassName("androidx.compose.ui.unit", "dp")

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGenerator.kt
@@ -111,6 +111,8 @@ internal class TypographyTokenGenerator(
         super.generateCompose()
         ktFileBuilder.addImport(KtFileBuilder.TypeSp)
         ktFileBuilder.addImport(KtFileBuilder.TypeFontWeight)
+        ktFileBuilder.addImport(KtFileBuilder.TypeLineHeightStyle)
+        ktFileBuilder.addImport(KtFileBuilder.TypePlatformTextStyle)
         ktFileBuilder.build(outputLocation)
     }
 
@@ -316,6 +318,11 @@ internal class TypographyTokenGenerator(
             "fontFamily = FontTokens.${
                 tokenValue.fontFamilyRef.split('.').last()
             }",
+            "lineHeightStyle = LineHeightStyle(" +
+                "alignment = LineHeightStyle.Alignment.Center, " +
+                "trim = LineHeightStyle.Trim.None" +
+                ")",
+            "platformStyle = PlatformTextStyle(includeFontPadding = false)",
         )
         appendProperty(name, KtFileBuilder.TypeTextStyle, initializer, description)
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/validator/ColorTokenValidator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/validator/ColorTokenValidator.kt
@@ -18,7 +18,7 @@ internal object ColorTokenValidator : TokenValidator<String> {
             !colorPaletteRegex.matches(tokenValue)
         ) {
             throw ThemeBuilderException(
-                "Color token $tokenName has invalid value: $tokenValue. " +
+                "Token $tokenName has invalid color value: $tokenValue. " +
                     "Color value should be rgb/argb hex " +
                     "or color palette reference, for example [general.red.100][0.5]",
             )

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/validator/ShadowTokenValidator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/validator/ShadowTokenValidator.kt
@@ -6,5 +6,7 @@ import com.sdds.plugin.themebuilder.internal.token.ShadowTokenValue
  * Валидатор значений токенов теней [ShadowTokenValue]
  */
 internal object ShadowTokenValidator : TokenValidator<ShadowTokenValue> {
-    override fun validate(tokenValue: ShadowTokenValue, tokenName: String) = Unit
+    override fun validate(tokenValue: ShadowTokenValue, tokenName: String) {
+        ColorTokenValidator.validate(tokenValue.color, tokenName)
+    }
 }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/validator/ColorTokenValidatorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/validator/ColorTokenValidatorTest.kt
@@ -23,7 +23,7 @@ class ColorTokenValidatorTest {
                 ColorTokenValidator.validate(it, TOKEN_NAME)
             }
             Assert.assertEquals(
-                "Color token $TOKEN_NAME has invalid value: $it. " +
+                "Token $TOKEN_NAME has invalid color value: $it. " +
                     "Color value should be rgb/argb hex " +
                     "or color palette reference, for example [general.red.100][0.5]",
                 exception.message,

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/validator/ShadowTokenValidatorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/validator/ShadowTokenValidatorTest.kt
@@ -1,0 +1,75 @@
+package com.sdds.plugin.themebuilder.internal.validator
+
+import com.sdds.plugin.themebuilder.internal.exceptions.ThemeBuilderException
+import com.sdds.plugin.themebuilder.internal.token.ShadowTokenValue
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Unit-тесты [ShadowTokenValidator]
+ */
+class ShadowTokenValidatorTest {
+
+    @Test
+    fun `ShapeTokenValidator должен успешно проводить проверки`() {
+        validData.forEach {
+            ShadowTokenValidator.validate(it, TOKEN_NAME)
+        }
+    }
+
+    @Test
+    fun `ShapeTokenValidator должен выбрасывать исключение`() {
+        invalidData.forEach {
+            Assert.assertThrows(ThemeBuilderException::class.java) {
+                ShadowTokenValidator.validate(it, TOKEN_NAME)
+            }
+        }
+    }
+
+    private companion object {
+        const val TOKEN_NAME = "token_name"
+
+        val validData = listOf(
+            ShadowTokenValue("#33aaeeFF", 2f),
+            ShadowTokenValue("#ffffff", -2.2f),
+            ShadowTokenValue("#FFffff", 20f),
+            ShadowTokenValue("#fff", 1.5f),
+            ShadowTokenValue("#EEE", 0f),
+            ShadowTokenValue("#5e5e5e33", 2f),
+            ShadowTokenValue("[general.red.100]", 2f),
+            ShadowTokenValue("[general.blue.100][0]", 2f),
+            ShadowTokenValue("[general.green.100][0.0]", 2f),
+            ShadowTokenValue("[custom.red.200][0.00]", 2f),
+            ShadowTokenValue("[general.red.150][0.00]", 2f),
+            ShadowTokenValue("[general.red.300][0.01]", 2f),
+            ShadowTokenValue("[general.red.300][0.99]", 2f),
+            ShadowTokenValue("[general.red.100][0.341]", 2f),
+            ShadowTokenValue("[custom.red.550][1]", 2f),
+            ShadowTokenValue("[general.red.100][1.0]", 2f),
+            ShadowTokenValue("[general.red.1000][1.00]", 2f),
+        )
+
+        val invalidData = listOf(
+            ShadowTokenValue("444", -2f),
+            ShadowTokenValue("aaa", -22f),
+            ShadowTokenValue("word", 0f),
+            ShadowTokenValue("#ffeeffeeee", 1.3f),
+            ShadowTokenValue("#ffff", 2f),
+            ShadowTokenValue("#ffffa", 2f),
+            ShadowTokenValue("ffffa", 2f),
+            ShadowTokenValue("#ssssss", 2f),
+            ShadowTokenValue("[generalred200]", 2f),
+            ShadowTokenValue("[200]", 2f),
+            ShadowTokenValue("[200][0.01]", 2f),
+            ShadowTokenValue("[red.200]", 2f),
+            ShadowTokenValue("[general.red.-200]", 2f),
+            ShadowTokenValue("[general.blue.300][-0.01]", 2f),
+            ShadowTokenValue("[general.green.1000][1.01]", 2f),
+            ShadowTokenValue("[general.green.big][1.01]", 2f),
+            ShadowTokenValue("[general.green.1000][2.01]", 2f),
+            ShadowTokenValue("[general.green.1000][1.00", 2f),
+            ShadowTokenValue("general.green.1000][1.00]", 2f),
+            ShadowTokenValue("[general.200.1000][1.00]", 2f),
+        )
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/TestTypographyOutputKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/TestTypographyOutputKt.txt
@@ -1,7 +1,9 @@
 package com.test
 
+import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.unit.sp
 
 public object TypographyLargeTokens {
@@ -14,6 +16,9 @@ public object TypographyLargeTokens {
                 lineHeight = 128.0.sp,
                 letterSpacing = 0.02.sp,
                 fontFamily = FontTokens.sans,
+                lineHeightStyle = LineHeightStyle(alignment = LineHeightStyle.Alignment.Center, trim
+                    = LineHeightStyle.Trim.None),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
             )
 
     /**
@@ -25,6 +30,9 @@ public object TypographyLargeTokens {
                 lineHeight = 128.0.sp,
                 letterSpacing = 0.02.sp,
                 fontFamily = FontTokens.sans,
+                lineHeightStyle = LineHeightStyle(alignment = LineHeightStyle.Alignment.Center, trim
+                    = LineHeightStyle.Trim.None),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
             )
 }
 
@@ -38,6 +46,9 @@ public object TypographySmallTokens {
                 lineHeight = 124.0.sp,
                 letterSpacing = 0.04.sp,
                 fontFamily = FontTokens.sans,
+                lineHeightStyle = LineHeightStyle(alignment = LineHeightStyle.Alignment.Center, trim
+                    = LineHeightStyle.Trim.None),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
             )
 
     /**
@@ -49,6 +60,9 @@ public object TypographySmallTokens {
                 lineHeight = 72.0.sp,
                 letterSpacing = 0.02.sp,
                 fontFamily = FontTokens.sans,
+                lineHeightStyle = LineHeightStyle(alignment = LineHeightStyle.Alignment.Center, trim
+                    = LineHeightStyle.Trim.None),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
             )
 }
 
@@ -62,6 +76,9 @@ public object TypographyMediumTokens {
                 lineHeight = 124.0.sp,
                 letterSpacing = 0.04.sp,
                 fontFamily = FontTokens.sans,
+                lineHeightStyle = LineHeightStyle(alignment = LineHeightStyle.Alignment.Center, trim
+                    = LineHeightStyle.Trim.None),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
             )
 
     /**
@@ -73,5 +90,8 @@ public object TypographyMediumTokens {
                 lineHeight = 96.0.sp,
                 letterSpacing = 0.02.sp,
                 fontFamily = FontTokens.sans,
+                lineHeightStyle = LineHeightStyle(alignment = LineHeightStyle.Alignment.Center, trim
+                    = LineHeightStyle.Trim.None),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
             )
 }

--- a/tokens/caldera.online.compose/build.gradle.kts
+++ b/tokens/caldera.online.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/flamingo.compose/build.gradle.kts
+++ b/tokens/flamingo.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/plasma.b2c.compose/build.gradle.kts
+++ b/tokens/plasma.b2c.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/plasma.web.compose/build.gradle.kts
+++ b/tokens/plasma.web.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sberhealth.compose/build.gradle.kts
+++ b/tokens/sberhealth.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sbermarket.business.compose/build.gradle.kts
+++ b/tokens/sbermarket.business.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sbermarket.compose/build.gradle.kts
+++ b/tokens/sbermarket.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sbermarket.metro.compose/build.gradle.kts
+++ b/tokens/sbermarket.metro.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sbermarket.selgros.compose/build.gradle.kts
+++ b/tokens/sbermarket.selgros.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sbermarket.wlbusiness.compose/build.gradle.kts
+++ b/tokens/sbermarket.wlbusiness.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sberonline.compose/build.gradle.kts
+++ b/tokens/sberonline.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sberprime.compose/build.gradle.kts
+++ b/tokens/sberprime.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/sdds.serv.compose/build.gradle.kts
+++ b/tokens/sdds.serv.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }

--- a/tokens/stylessalute.compose/build.gradle.kts
+++ b/tokens/stylessalute.compose/build.gradle.kts
@@ -18,6 +18,6 @@ themeBuilder {
 }
 
 dependencies {
-    
+
     implementation(libs.base.androidX.compose.foundation)
 }


### PR DESCRIPTION
* Добавил фикс LineHeight в Compose токены типографики
* Добавил потерявшуюся проверку цвета для токенов теней
* Закоммитил исправления отступов в модулях tokens