### PR TITLE
fix(sdds-acore/theme-builder): Fix color and gradient fun names

### DIFF
--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeColorAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeColorAttributeGenerator.kt
@@ -9,8 +9,8 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.ColorTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedLightAndDark
+import com.sdds.plugin.themebuilder.internal.utils.snakeToCamelCase
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
-import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор Compose-атрибутов цвета.
@@ -33,7 +33,8 @@ internal class ComposeColorAttributeGenerator(
         ktFileBuilderFactory.create(colorClassName)
     }
 
-    private val colorClassName = "${themeName.capitalized()}Colors"
+    private val camelThemeName = themeName.snakeToCamelCase()
+    private val colorClassName = "${camelThemeName}Colors"
     private val colorClassType by unsafeLazy {
         colorKtFileBuilder.getInternalClassType(colorClassName)
     }
@@ -70,7 +71,7 @@ internal class ComposeColorAttributeGenerator(
                     },
                 ),
                 annotation = KtFileBuilder.TypeAnnotationImmutable,
-                description = "Цвета $themeName",
+                description = "Цвета $camelThemeName",
             )
 
             colorAttributes.forEach { color ->
@@ -132,7 +133,7 @@ internal class ComposeColorAttributeGenerator(
 
     private fun addLightColorsFun() {
         colorKtFileBuilder.appendRootFun(
-            name = "light${themeName}Colors",
+            name = "light${camelThemeName}Colors",
             params = colorAttributes.map {
                 val defaultValue = if (tokenData?.light?.get(it) != null) {
                     "LightColorTokens.${tokenData?.light?.get(it)}"
@@ -159,7 +160,7 @@ internal class ComposeColorAttributeGenerator(
 
     private fun addDarkColorsFun() {
         colorKtFileBuilder.appendRootFun(
-            name = "dark${themeName}Colors",
+            name = "dark${camelThemeName}Colors",
             params = colorAttributes.map {
                 val defaultValue = if (tokenData?.dark?.get(it) != null) {
                     "DarkColorTokens.${tokenData?.dark?.get(it)}"
@@ -189,7 +190,7 @@ internal class ComposeColorAttributeGenerator(
             name = "Local$colorClassName",
             typeName = KtFileBuilder.TypeProvidableCompositionLocal,
             parameterizedType = colorClassType,
-            initializer = "staticCompositionLocalOf { light${themeName}Colors() }",
+            initializer = "staticCompositionLocalOf { light${camelThemeName}Colors() }",
             modifiers = listOf(INTERNAL),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeGradientAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeGradientAttributeGenerator.kt
@@ -11,8 +11,8 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileFromResourcesBuilderF
 import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.GradientTokenResult.TokenData
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedLightAndDark
+import com.sdds.plugin.themebuilder.internal.utils.snakeToCamelCase
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
-import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор Compose-атрибутов градиента.
@@ -41,7 +41,8 @@ internal class ComposeGradientAttributeGenerator(
         ktFileFromResourcesBuilderFactory.create()
     }
 
-    private val gradientClassName = "${themeName.capitalized()}Gradients"
+    private val camelThemeName = themeName.snakeToCamelCase()
+    private val gradientClassName = "${camelThemeName}Gradients"
 
     fun setGradientTokenData(data: TokenData) {
         tokenData = data
@@ -135,7 +136,7 @@ internal class ComposeGradientAttributeGenerator(
                     },
                 ),
                 annotation = KtFileBuilder.TypeAnnotationImmutable,
-                description = "Градиенты $themeName",
+                description = "Градиенты $camelThemeName",
                 modifiers = listOf(DATA),
             )
         }
@@ -146,14 +147,14 @@ internal class ComposeGradientAttributeGenerator(
             name = "Local$gradientClassName",
             typeName = KtFileBuilder.TypeProvidableCompositionLocal,
             parameterizedType = gradientKtFileBuilder.getInternalClassType(gradientClassName),
-            initializer = "staticCompositionLocalOf { light${themeName}Gradients() }",
+            initializer = "staticCompositionLocalOf { light${camelThemeName}Gradients() }",
             modifiers = listOf(INTERNAL),
         )
     }
 
     private fun addLightGradientsFun() {
         gradientKtFileBuilder.appendRootFun(
-            name = "light${themeName}Gradients",
+            name = "light${camelThemeName}Gradients",
             params = gradientAttributes.map {
                 KtFileBuilder.FunParameter(
                     name = it,
@@ -226,7 +227,7 @@ internal class ComposeGradientAttributeGenerator(
 
     private fun addDarkGradientsFun() {
         gradientKtFileBuilder.appendRootFun(
-            name = "dark${themeName}Gradients",
+            name = "dark${camelThemeName}Gradients",
             params = gradientAttributes.map {
                 KtFileBuilder.FunParameter(
                     name = it,

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeShapeAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeShapeAttributeGenerator.kt
@@ -7,8 +7,8 @@ import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder.Modifier.INTE
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.ShapeTokenResult
+import com.sdds.plugin.themebuilder.internal.utils.snakeToCamelCase
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
-import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор Compose-атрибутов форм.
@@ -29,7 +29,8 @@ internal class ComposeShapeAttributeGenerator(
         ktFileBuilderFactory.create(shapeClassName)
     }
 
-    private val shapeClassName = "${themeName.capitalized()}Shapes"
+    private val camelThemeName = themeName.snakeToCamelCase()
+    private val shapeClassName = "${camelThemeName}Shapes"
 
     fun setShapeTokenData(shapes: List<ShapeTokenResult.TokenData>) {
         this.shapes.clear()
@@ -61,7 +62,7 @@ internal class ComposeShapeAttributeGenerator(
                     },
                 ),
                 annotation = KtFileBuilder.TypeAnnotationImmutable,
-                description = "Формы $themeName",
+                description = "Формы $camelThemeName",
                 modifiers = listOf(DATA),
             )
         }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeThemeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeThemeGenerator.kt
@@ -7,8 +7,8 @@ import com.sdds.plugin.themebuilder.internal.generator.data.ColorTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.TypographyTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedLightAndDark
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedScreenClasses
+import com.sdds.plugin.themebuilder.internal.utils.snakeToCamelCase
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
-import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор темы для Compose
@@ -23,8 +23,8 @@ internal class ComposeThemeGenerator(
         ktFileBuilderFactory.create(themeClassName)
     }
 
-    private val capitalizedThemeName = themeName.capitalized()
-    private val themeClassName = "${capitalizedThemeName}Theme"
+    private val camelThemeName = themeName.snakeToCamelCase()
+    private val themeClassName = "${camelThemeName}Theme"
 
     private var textSelectionHandleColor: String? = null
     private var textStyleColor: String? = null
@@ -60,16 +60,16 @@ internal class ComposeThemeGenerator(
     }
 
     private val colorAttributesClassType by unsafeLazy {
-        themeKtFileBuilder.getInternalClassType("${capitalizedThemeName}Colors")
+        themeKtFileBuilder.getInternalClassType("${camelThemeName}Colors")
     }
     private val gradientAttributesClassType by unsafeLazy {
-        themeKtFileBuilder.getInternalClassType("${capitalizedThemeName}Gradients")
+        themeKtFileBuilder.getInternalClassType("${camelThemeName}Gradients")
     }
     private val shapeAttributesClassType by unsafeLazy {
-        themeKtFileBuilder.getInternalClassType("${capitalizedThemeName}Shapes")
+        themeKtFileBuilder.getInternalClassType("${camelThemeName}Shapes")
     }
     private val typographyAttributesClassType by unsafeLazy {
-        themeKtFileBuilder.getInternalClassType("${capitalizedThemeName}Typography")
+        themeKtFileBuilder.getInternalClassType("${camelThemeName}Typography")
     }
 
     private fun addThemeFun() {
@@ -95,7 +95,7 @@ internal class ComposeThemeGenerator(
                     KtFileBuilder.FunParameter(
                         name = "typography",
                         type = typographyAttributesClassType,
-                        defValue = "dynamic${capitalizedThemeName}Typography()",
+                        defValue = "dynamic${camelThemeName}Typography()",
                     ),
                     KtFileBuilder.FunParameter(
                         name = "content",
@@ -106,7 +106,7 @@ internal class ComposeThemeGenerator(
                 ),
                 body = listOf(buildThemeFunBody()),
                 annotation = KtFileBuilder.TypeAnnotationComposable,
-                description = "Базовая тема $capitalizedThemeName",
+                description = "Базовая тема $camelThemeName",
             )
         }
     }
@@ -124,10 +124,10 @@ internal class ComposeThemeGenerator(
                 appendLine()
             }
             val compositionLocalProviderFunParametersList = mutableListOf(
-                "Local${capitalizedThemeName}Colors provides rememberColors",
-                "Local${capitalizedThemeName}Gradients provides gradients",
-                "Local${capitalizedThemeName}Typography provides typography",
-                "Local${capitalizedThemeName}Shapes provides shapes",
+                "Local${camelThemeName}Colors provides rememberColors",
+                "Local${camelThemeName}Gradients provides gradients",
+                "Local${camelThemeName}Typography provides typography",
+                "Local${camelThemeName}Shapes provides shapes",
             )
             textSelectionHandleColor?.let {
                 compositionLocalProviderFunParametersList.add(

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeTypographyAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeTypographyAttributeGenerator.kt
@@ -9,8 +9,8 @@ import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.TypographyTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedScreenClasses
 import com.sdds.plugin.themebuilder.internal.token.TypographyToken.ScreenClass
+import com.sdds.plugin.themebuilder.internal.utils.snakeToCamelCase
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
-import org.gradle.configurationcache.extensions.capitalized
 
 /**
  * Генератор Compose-атрибутов типографики.
@@ -35,7 +35,9 @@ internal class ComposeTypographyAttributeGenerator(
     private val ktFileFromResBuilder by unsafeLazy {
         ktFileFromResourcesBuilderFactory.create()
     }
-    private val typographyClassName = "${themeName.capitalized()}Typography"
+
+    private val camelThemeName = themeName.snakeToCamelCase()
+    private val typographyClassName = "${camelThemeName}Typography"
     private val typographyClassType by unsafeLazy {
         typographyKtFileBuilder.getInternalClassType(typographyClassName)
     }
@@ -129,7 +131,7 @@ internal class ComposeTypographyAttributeGenerator(
                     modifiers = listOf(Modifier.INTERNAL),
                 ),
                 annotation = KtFileBuilder.TypeAnnotationImmutable,
-                description = "Типографика $themeName",
+                description = "Типографика $camelThemeName",
                 modifiers = listOf(Modifier.DATA),
             )
         }
@@ -200,7 +202,7 @@ internal class ComposeTypographyAttributeGenerator(
 
     private fun addLocalTextStyleVal() {
         typographyKtFileBuilder.appendRootVal(
-            name = "Local${themeName.capitalized()}TextStyle",
+            name = "Local${camelThemeName}TextStyle",
             typeName = KtFileBuilder.TypeProvidableCompositionLocal,
             parameterizedType = KtFileBuilder.TypeTextStyle,
             initializer = "compositionLocalOf(structuralEqualityPolicy()) { TextStyle.Default }",
@@ -226,9 +228,9 @@ internal class ComposeTypographyAttributeGenerator(
             modifiers = listOf(Modifier.INTERNAL),
             annotation = KtFileBuilder.TypeAnnotationComposable,
             body = listOf(
-                "val mergedStyle = Local${themeName.capitalized()}TextStyle.current.merge(value)\n",
+                "val mergedStyle = Local${camelThemeName}TextStyle.current.merge(value)\n",
                 "CompositionLocalProvider(" +
-                    "Local${themeName.capitalized()}TextStyle provides mergedStyle, " +
+                    "Local${camelThemeName}TextStyle provides mergedStyle, " +
                     "content = content)",
             ),
         )

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewGradientAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewGradientAttributeGenerator.kt
@@ -11,8 +11,8 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileFromResourcesBuilderF
 import com.sdds.plugin.themebuilder.internal.generator.SimpleBaseGenerator
 import com.sdds.plugin.themebuilder.internal.generator.data.GradientTokenResult.TokenData
 import com.sdds.plugin.themebuilder.internal.generator.data.mergedLightAndDark
+import com.sdds.plugin.themebuilder.internal.utils.snakeToCamelCase
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
-import org.gradle.configurationcache.extensions.capitalized
 import java.util.Locale
 
 /**
@@ -44,7 +44,8 @@ internal class ViewGradientAttributeGenerator(
         ktFileFromResourcesBuilderFactory.create(frameworkPackage = KtFileFromResourcesBuilderFactory.Package.VS)
     }
 
-    private val gradientClassName = "${themeName.capitalized()}Gradients"
+    private val camelThemeName = themeName.snakeToCamelCase()
+    private val gradientClassName = "${camelThemeName}Gradients"
 
     fun setGradientTokenData(data: TokenData) {
         tokenData = data
@@ -129,7 +130,7 @@ internal class ViewGradientAttributeGenerator(
                         )
                     },
                 ),
-                description = "Градиенты $themeName.",
+                description = "Градиенты $camelThemeName.",
                 modifiers = listOf(DATA),
             )
         }
@@ -137,7 +138,7 @@ internal class ViewGradientAttributeGenerator(
 
     private fun addLightGradientsVal() {
         gradientKtFileBuilder.appendRootVal(
-            name = "light${themeName.capitalized()}Gradients",
+            name = "light${camelThemeName}Gradients",
             typeName = gradientKtFileBuilder.getInternalClassType(gradientClassName),
             initializer = "$gradientClassName(\n${
                 gradientAttributes.joinToString(separator = ",") {
@@ -149,7 +150,7 @@ internal class ViewGradientAttributeGenerator(
 
     private fun addDarkGradientsVal() {
         gradientKtFileBuilder.appendRootVal(
-            name = "dark${themeName.capitalized()}Gradients",
+            name = "dark${camelThemeName}Gradients",
             typeName = gradientKtFileBuilder.getInternalClassType(gradientClassName),
             initializer = "$gradientClassName(\n${
                 gradientAttributes.joinToString(separator = ", ") {
@@ -342,7 +343,7 @@ internal class ViewGradientAttributeGenerator(
 
     private fun addGradientsFun() {
         gradientKtFileBuilder.appendRootFun(
-            name = "${themeName.decapitalize(Locale.getDefault())}Gradients",
+            name = "${camelThemeName.decapitalize(Locale.getDefault())}Gradients",
             params = listOf(
                 KtFileBuilder.FunParameter(
                     name = "context",
@@ -353,7 +354,7 @@ internal class ViewGradientAttributeGenerator(
             body = listOf(
                 "val isDarkMode = context.resources.configuration.uiMode and\n" +
                     "            Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES\n",
-                "return if (isDarkMode) dark${themeName}Gradients else light${themeName}Gradients",
+                "return if (isDarkMode) dark${camelThemeName}Gradients else light${camelThemeName}Gradients",
             ),
             description = "Возвращает объект [ViewGradients], " +
                 "который соответствует текущему режиму dark/light для данного [context].",

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewThemeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewThemeGenerator.kt
@@ -85,6 +85,7 @@ internal class ViewThemeGenerator(
         }
 
         with(lightThemeXmlFileBuilder) {
+            appendStyle(capitalizedResPrefix)
             addStyleWithAttrs(
                 {
                     if (colorAttributes.isNotEmpty()) appendComment("Light colors")

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
@@ -44,7 +44,7 @@ class ViewThemeGeneratorTest {
             xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr", "TestTheme"),
             outputResDir = mockOutputResDir,
             parentThemeName = "Sdds.Theme",
-            themeName = "TestTheme",
+            themeName = "test_Theme",
             resPrefix = "thmbldr",
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-theme-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-theme-output.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources>
+    <style name="Thmbldr"/>
     <style name="Thmbldr.TestTheme" parent="Sdds.Theme">
         <!--Light colors-->
         <item name="thmbldr_textPrimary">@color/thmbldr_light_text_primary</item>


### PR DESCRIPTION
* Поправил наименования функций и классов в файлах с атрибутами для compose. Теперь любой themeName сначала приводится к СamelCase и потом используется в генерируемом коде.
* Также добавил рутовый стиль состоящий из ResPrefix, даже если генерируется тема, а не только токены.