### PR TITLE
feat(sdds-acore/theme-builder): Support font style for low api levels

### DIFF
--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
@@ -8,6 +8,7 @@ import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.KtFileFromResourcesBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.XmlFontFamilyDocumentBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.XmlResourcesDocumentBuilderFactory
+import com.sdds.plugin.themebuilder.internal.fonts.FontsAggregator
 import com.sdds.plugin.themebuilder.internal.serializer.Serializer
 import com.sdds.plugin.themebuilder.internal.token.ColorToken
 import com.sdds.plugin.themebuilder.internal.token.FontToken
@@ -148,6 +149,7 @@ abstract class GenerateThemeTask : DefaultTask() {
     abstract val outputResDirPath: Property<String>
 
     private val dimensAggregator by unsafeLazy { DimensAggregator() }
+    private val fontsAggregator by unsafeLazy { FontsAggregator() }
     private val generatorFactory by unsafeLazy {
         GeneratorFactory(
             outputDirPath = outputDirPath.get(),
@@ -156,6 +158,7 @@ abstract class GenerateThemeTask : DefaultTask() {
             target = target.get(),
             generatorMode = generatorMode.get(),
             dimensAggregator = dimensAggregator,
+            fontsAggregator = fontsAggregator,
             xmlResourcesDocumentBuilderFactory = XmlResourcesDocumentBuilderFactory(
                 resourcesPrefix.get(),
                 themeName.get(),

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/download/FontDownloader.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/download/FontDownloader.kt
@@ -1,7 +1,6 @@
 package com.sdds.plugin.themebuilder.internal.download
 
-import com.sdds.plugin.themebuilder.internal.utils.camelToSnakeCase
-import com.sdds.plugin.themebuilder.internal.utils.fileNameFromUrl
+import com.sdds.plugin.themebuilder.internal.utils.fontFileNameFromUrl
 import java.io.File
 
 /**
@@ -41,9 +40,4 @@ internal class FontDownloaderWithCache(
         downloadedFonts[url] = fontFile
         return fontFile
     }
-
-    private fun String.fontFileNameFromUrl(): String =
-        fileNameFromUrl()
-            .replace('-', '_')
-            .camelToSnakeCase()
 }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
@@ -4,6 +4,7 @@ import com.sdds.plugin.themebuilder.ThemeBuilderMode
 import com.sdds.plugin.themebuilder.internal.ThemeBuilderTarget
 import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder.OutputLocation
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
+import com.sdds.plugin.themebuilder.internal.fonts.FontsAggregator
 import com.sdds.plugin.themebuilder.internal.generator.ColorTokenGenerator
 import com.sdds.plugin.themebuilder.internal.generator.DimenTokenGenerator
 import com.sdds.plugin.themebuilder.internal.generator.FontTokenGenerator
@@ -28,7 +29,9 @@ import java.io.File
  * @param outputResDirPath путь для сохранения xml-файлов
  * @param projectDir директория проекта
  * @param target целевой фреймворк
+ * @param generatorMode режим работы генератора (тема или только токены)
  * @param dimensAggregator агрегатор размеров
+ * @param fontsAggregator агрегатор шрифтов
  * @param xmlResourcesDocumentBuilderFactory фабрика делегата построения xml файлов ресурсов
  * @param xmlFontFamilyDocumentBuilderFactory фабрика делегата построения xml файлов font-family
  * @param fontDownloaderFactory фабрика загрузчика шрифтов
@@ -48,6 +51,7 @@ internal class GeneratorFactory(
     private val target: ThemeBuilderTarget,
     private val generatorMode: ThemeBuilderMode,
     private val dimensAggregator: DimensAggregator,
+    private val fontsAggregator: FontsAggregator,
     private val xmlResourcesDocumentBuilderFactory: XmlResourcesDocumentBuilderFactory,
     private val xmlFontFamilyDocumentBuilderFactory: XmlFontFamilyDocumentBuilderFactory,
     private val fontDownloaderFactory: FontDownloaderFactory,
@@ -225,6 +229,7 @@ internal class GeneratorFactory(
             namespace,
             resPrefix,
             fonts,
+            fontsAggregator,
         )
     }
 
@@ -241,6 +246,7 @@ internal class GeneratorFactory(
             ktFileBuilderFactory,
             resourceReferenceProvider,
             typography,
+            fontsAggregator,
         )
     }
 

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/fonts/FontData.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/fonts/FontData.kt
@@ -1,0 +1,14 @@
+package com.sdds.plugin.themebuilder.internal.fonts
+
+/**
+ * Данные о шрифте (font)
+ *
+ * @property fontName название файла шрифта без расширения
+ * @property fontWeight вес шрифта
+ * @property fontStyle стиль шрифта
+ */
+internal data class FontData(
+    val fontName: String,
+    val fontWeight: Int,
+    val fontStyle: String,
+)

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/fonts/FontsAggregator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/fonts/FontsAggregator.kt
@@ -1,0 +1,22 @@
+package com.sdds.plugin.themebuilder.internal.fonts
+
+/**
+ * Агрегатор шрифтов.
+ * Нужен для сбора данных о шрифтах и последующего использования данных в генераторе стилей типографики.
+ */
+internal class FontsAggregator {
+    private val mutableFonts = mutableMapOf<String, Set<FontData>>()
+
+    /**
+     * Наборы данных о шрифтах (значение) для каждого семейства (ключ)
+     */
+    val fonts: Map<String, Set<FontData>>
+        get() = mutableFonts
+
+    /**
+     * Добавляет набор данных о шрифтах [FontData] для семейства [fontFamily]
+     */
+    fun addFont(fontFamily: String, fonts: Set<FontData>) {
+        mutableFonts[fontFamily] = fonts
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/ResourceReferenceProvider.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/ResourceReferenceProvider.kt
@@ -1,6 +1,7 @@
 package com.sdds.plugin.themebuilder.internal.utils
 
 import com.sdds.plugin.themebuilder.internal.dimens.DimenData
+import com.sdds.plugin.themebuilder.internal.fonts.FontData
 import org.gradle.configurationcache.extensions.capitalized
 
 /**
@@ -43,12 +44,11 @@ internal class ResourceReferenceProvider(
     }
 
     /**
-     * Возвращает ссылку на fontFamily с названием [name].
-     * Например, если шрифт называется display, и ресурсам задан префикс "pref",
-     * то функция вернет ссылку @font/pref_display
+     * Возвращает ссылку на шрифт с названием из [fontData].
+     * Например, если шрифт называется display_bold, то функция вернет ссылку @font/display_bold
      */
-    fun font(name: String): String {
-        return "@font/${name.withPrefixIfNeed(resourcePrefix)}"
+    fun font(fontData: FontData): String {
+        return "@font/${fontData.fontName}"
     }
 
     /**

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtils.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/utils/StringUtils.kt
@@ -43,3 +43,11 @@ internal fun String.withPrefixIfNeed(prefix: String? = null, delimiter: String =
 internal fun String.fileNameFromUrl(): String =
     this.split('/')
         .last()
+
+/**
+ * Извлекает имя файла шрифта из ссылки и приводит к snake_case
+ */
+internal fun String.fontFileNameFromUrl(): String =
+    fileNameFromUrl()
+        .replace('-', '_')
+        .camelToSnakeCase()

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/fonts/FontsAggregatorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/fonts/FontsAggregatorTest.kt
@@ -1,0 +1,37 @@
+package com.sdds.plugin.themebuilder.internal.fonts
+
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Unit-тесты [FontsAggregator]
+ */
+class FontsAggregatorTest {
+    @Test
+    fun `FontsAggregator сохраняет данные о шрифтах`() {
+        val testFontFamily = "testFontFamily"
+        val underTest = FontsAggregator()
+
+        underTest.addFont(testFontFamily, fontDataSet)
+
+        Assert.assertNull(underTest.fonts["wrongFontFamily"])
+        Assert.assertEquals(fontDataSet, underTest.fonts[testFontFamily])
+        Assert.assertTrue(
+            underTest.fonts[testFontFamily]?.contains(
+                FontData(
+                    "testFontFamily",
+                    400,
+                    "normal",
+                ),
+            ) == true,
+        )
+    }
+
+    private companion object {
+        val fontDataSet = setOf(
+            FontData("testFontFamily", 200, "normal"),
+            FontData("testFontFamily", 400, "normal"),
+            FontData("testFontFamily", 600, "italic"),
+        )
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/FontTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/FontTokenGeneratorTest.kt
@@ -8,6 +8,7 @@ import com.sdds.plugin.themebuilder.internal.download.FontDownloaderWithCache
 import com.sdds.plugin.themebuilder.internal.factory.FontDownloaderFactory
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.XmlFontFamilyDocumentBuilderFactory
+import com.sdds.plugin.themebuilder.internal.fonts.FontsAggregator
 import com.sdds.plugin.themebuilder.internal.serializer.Serializer
 import com.sdds.plugin.themebuilder.internal.token.FontToken
 import com.sdds.plugin.themebuilder.internal.token.FontTokenValue
@@ -65,6 +66,7 @@ class FontTokenGeneratorTest {
             namespace = "com.test",
             resPrefix = "thmbldr",
             fontTokenValues = fontTokenValues,
+            fontsAggregator = FontsAggregator(),
         )
     }
 

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/TypographyTokenGeneratorTest.kt
@@ -5,6 +5,8 @@ import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.factory.XmlResourcesDocumentBuilderFactory
+import com.sdds.plugin.themebuilder.internal.fonts.FontData
+import com.sdds.plugin.themebuilder.internal.fonts.FontsAggregator
 import com.sdds.plugin.themebuilder.internal.serializer.Serializer
 import com.sdds.plugin.themebuilder.internal.token.TypographyToken
 import com.sdds.plugin.themebuilder.internal.token.TypographyTokenValue
@@ -38,6 +40,7 @@ class TypographyTokenGeneratorTest {
     private lateinit var outputKt: ByteArrayOutputStream
     private lateinit var mockOutputResDir: File
     private lateinit var mockDimensAggregator: DimensAggregator
+    private lateinit var mockFontsAggregator: FontsAggregator
     private lateinit var underTest: TypographyTokenGenerator
 
     @Before
@@ -50,6 +53,9 @@ class TypographyTokenGeneratorTest {
         outputKt = ByteArrayOutputStream()
         mockOutputResDir = mockk(relaxed = true)
         mockDimensAggregator = mockk(relaxed = true)
+        mockFontsAggregator = mockk(relaxed = true) {
+            every { fonts } returns fontsAggregatorData
+        }
         underTest = TypographyTokenGenerator(
             outputLocation = KtFileBuilder.OutputLocation.Stream(outputKt),
             outputResDir = mockOutputResDir,
@@ -59,6 +65,7 @@ class TypographyTokenGeneratorTest {
             ktFileBuilderFactory = KtFileBuilderFactory("com.test"),
             resourceReferenceProvider = ResourceReferenceProvider("thmbldr", "TestTheme"),
             typographyTokenValues = typographyTokenValues,
+            fontsAggregator = mockFontsAggregator,
         )
     }
 
@@ -121,6 +128,13 @@ class TypographyTokenGeneratorTest {
     }
 
     private companion object {
+        val fontsAggregatorData = mapOf(
+            "sans" to setOf(
+                FontData("sans", 300, "normal"),
+                FontData("sans", 400, "normal"),
+            ),
+        )
+
         val typographyTokenValues = mapOf(
             "screen-l.display.l.normal" to TypographyTokenValue(
                 fontFamilyRef = "fontFamily.sans",

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/ResourceReferenceProviderTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/utils/ResourceReferenceProviderTest.kt
@@ -1,6 +1,7 @@
 package com.sdds.plugin.themebuilder.internal.utils
 
 import com.sdds.plugin.themebuilder.internal.dimens.DimenData
+import com.sdds.plugin.themebuilder.internal.fonts.FontData
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -37,7 +38,7 @@ class ResourceReferenceProviderTest {
 
     @Test
     fun `ResourceReferenceProvider возвращает ссылку на font`() {
-        assertEquals("@font/thmbldr_display", underTest.font("display"))
+        assertEquals("@font/display", underTest.font(FontData("display", 200, "normal")))
     }
 
     @Test

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-large-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-large-output.xml
@@ -2,8 +2,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.TextLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">400</item>
+        <item name="android:textFontWeight" tools:targetApi="p">400</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textSize">@dimen/thmbldr_screen_s_text_l_normal_text_size</item>
@@ -11,8 +12,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.DisplayLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">300</item>
+        <item name="android:textFontWeight" tools:targetApi="p">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_normal_text_size</item>
@@ -20,8 +22,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.HeaderLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">400</item>
+        <item name="android:textFontWeight" tools:targetApi="p">400</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textSize">@dimen/thmbldr_screen_m_header_l_normal_text_size</item>
@@ -29,8 +32,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.DisplayLBold">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">300</item>
+        <item name="android:textFontWeight" tools:targetApi="p">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_bold_text_size</item>

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-output.xml
@@ -3,8 +3,9 @@
     <style name="Thmbldr.TestTheme.TextAppearance"/>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.TextLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">400</item>
+        <item name="android:textFontWeight" tools:targetApi="p">400</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textSize">@dimen/thmbldr_screen_s_text_l_normal_text_size</item>
@@ -12,8 +13,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.DisplayLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">300</item>
+        <item name="android:textFontWeight" tools:targetApi="p">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:textSize">@dimen/thmbldr_screen_m_display_l_normal_text_size</item>
@@ -21,8 +23,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.HeaderLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">400</item>
+        <item name="android:textFontWeight" tools:targetApi="p">400</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textSize">@dimen/thmbldr_screen_m_header_l_normal_text_size</item>
@@ -30,8 +33,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.DisplayLBold">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">300</item>
+        <item name="android:textFontWeight" tools:targetApi="p">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_bold_text_size</item>

--- a/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-small-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/typography-outputs/test-appearances-small-output.xml
@@ -2,8 +2,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.TextLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">400</item>
+        <item name="android:textFontWeight" tools:targetApi="p">400</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textSize">@dimen/thmbldr_screen_s_text_l_normal_text_size</item>
@@ -11,8 +12,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.DisplayLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">300</item>
+        <item name="android:textFontWeight" tools:targetApi="p">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:textSize">@dimen/thmbldr_screen_s_display_l_normal_text_size</item>
@@ -20,8 +22,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.HeaderLNormal">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">400</item>
+        <item name="android:textFontWeight" tools:targetApi="p">400</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textSize">@dimen/thmbldr_screen_m_header_l_normal_text_size</item>
@@ -29,8 +32,9 @@
     </style>
     <!--шрифт android-->
     <style name="Thmbldr.TestTheme.TextAppearance.DisplayLBold">
-        <item name="fontFamily">@font/thmbldr_sans</item>
+        <item name="fontFamily">@font/sans</item>
         <item name="fontWeight">300</item>
+        <item name="android:textFontWeight" tools:targetApi="p">300</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:textSize">@dimen/thmbldr_screen_l_display_l_bold_text_size</item>


### PR DESCRIPTION
* Исправлена проблема, когда не работает fontStyle на api < 28. В каждый стиль добавляется атрибут textFontWeight, и и в качестве fontFamily указывается не ссылка на ресурс fontFamily а ссылка на файл шрифта

Ниже скриншоты на эмуляторах с 24 и 33 api level
![image](https://github.com/user-attachments/assets/188f1ee2-2eb9-4037-8629-7805e3b5ffb9)

![image](https://github.com/user-attachments/assets/fe5013aa-e6e2-4292-b40a-cd6f16f45488)

