### PR TITLE
Feature/view theme parents

### DIFF
--- a/playground/theme-builder/build.gradle.kts
+++ b/playground/theme-builder/build.gradle.kts
@@ -13,10 +13,14 @@ android {
 }
 
 themeBuilder {
-    themeSource(url = "file://${projectDir.path}/json/test_theme.zip")
-    view(parentThemeName = "Sdds.Theme")
+    themeSource("file://${projectDir.path}/json/test_theme.zip")
+    view {
+        themeParents {
+            materialComponentsTheme("DayNight")
+        }
+    }
     compose()
-    ktPackage(ktPackage = "com.sdds.playground.themebuilder.tokens")
+    ktPackage("com.sdds.playground.themebuilder.tokens")
     mode(ThemeBuilderMode.THEME)
 }
 

--- a/playground/theme-builder/build.gradle.kts
+++ b/playground/theme-builder/build.gradle.kts
@@ -16,7 +16,7 @@ themeBuilder {
     themeSource("file://${projectDir.path}/json/test_theme.zip")
     view {
         themeParents {
-            materialComponentsTheme("DayNight")
+            customTheme("Thmbldr.Theme.App.Test")
         }
     }
     compose()

--- a/playground/theme-builder/src/main/res/values/theme.xml
+++ b/playground/theme-builder/src/main/res/values/theme.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Thmbldr.Theme"/>
+    <style name="Thmbldr.Theme.App"/>
+    <style name="Thmbldr.Theme.App.Test"/>
+</resources>

--- a/playground/theme-builder/src/main/res/values/theme.xml
+++ b/playground/theme-builder/src/main/res/values/theme.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <style name="Thmbldr"/>
     <style name="Thmbldr.Theme"/>
     <style name="Thmbldr.Theme.App"/>
     <style name="Thmbldr.Theme.App.Test"/>

--- a/sdds-core/plugin_theme_builder/README.MD
+++ b/sdds-core/plugin_theme_builder/README.MD
@@ -73,13 +73,22 @@ themeSource(url = "https://example.com/themes/theme.zip")
 </details>
 
 #### `view` (optional)
-Опциональная настройка генерации темы для view фреймворка. Можно указать `parentThemeName` - название родительской темы, от которой будет унаследована генерируемая тема. Если не указать, то сгенерированная тема для view не будет иметь parent'a. 
+Опциональная настройка генерации тем для view фреймворка. Можно указать список наследуемых тем. 
+Если не указать, то сгенерированная тема для view не будет иметь parent'a и будет представлена в двух директориях res/values и res/values-night.
 
 <details>
 <summary>Примеры настройки view</summary>
 
 ```kotlin
-view(parentThemeName = "Theme.MaterialComponents")
+view { 
+    themeParents {
+        materialComponentsTheme() // Наследуемся от Theme.MaterialComponents и генерируем единственную тему c темными токенами
+        materialComponentsTheme("DayNight") // Наследуемся от Theme.MaterialComponents.DayNight
+        appCompatTheme("Light.NoActionBar") // Наследуемся от Theme.AppCompat.Light.NoActionBar и генерируем единственную тему cо светлыми токенами
+        customTheme("Theme.App", ViewThemeType.DARK_LIGHT) // Наследумся от Theme.App и генерируем тему для двух режимов
+        customTheme("Theme.Custom", ViewThemeType.DARK) // Наследумся от Theme.Custom и генерируем единственную тему c темными токенами
+    }
+}
 ```
 ```kotlin
 view() // Тема не будет иметь parent'a

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
@@ -28,6 +28,7 @@ import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -113,10 +114,10 @@ abstract class GenerateThemeTask : DefaultTask() {
     abstract val resourcesPrefix: Property<String>
 
     /**
-     * Название родительской темы, от которой будет унаследована генерируемая тема
+     * Список родительских тем, от которых будут унаследованы генерируемые темы для view
      */
     @get:Input
-    abstract val parentThemeName: Property<String>
+    abstract val viewThemeParents: ListProperty<ViewThemeParent>
 
     /**
      * Режим генерации: токены или тема
@@ -170,7 +171,7 @@ abstract class GenerateThemeTask : DefaultTask() {
             resourceReferenceProvider = ResourceReferenceProvider(resourcesPrefix.get(), themeName.get()),
             namespace = namespace.get(),
             resPrefix = resourcesPrefix.get(),
-            parentThemeName = parentThemeName.get(),
+            viewThemeParents = viewThemeParents.get(),
             themeName = themeName.get(),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/GenerateThemeTask.kt
@@ -111,7 +111,7 @@ abstract class GenerateThemeTask : DefaultTask() {
      * Префикс для названий ресурсов токенов
      */
     @get:Input
-    abstract val resourcesPrefix: Property<String>
+    abstract val resourcesPrefixConfig: Property<ResourcePrefixConfig>
 
     /**
      * Список родительских тем, от которых будут унаследованы генерируемые темы для view
@@ -161,16 +161,19 @@ abstract class GenerateThemeTask : DefaultTask() {
             dimensAggregator = dimensAggregator,
             fontsAggregator = fontsAggregator,
             xmlResourcesDocumentBuilderFactory = XmlResourcesDocumentBuilderFactory(
-                resourcesPrefix.get(),
+                resourcesPrefixConfig.get().resourcePrefix,
                 themeName.get(),
             ),
             xmlFontFamilyDocumentBuilderFactory = XmlFontFamilyDocumentBuilderFactory(),
             fontDownloaderFactory = FontDownloaderFactory(),
             ktFileBuilderFactory = KtFileBuilderFactory(packageName.get()),
             ktFileFromResourcesBuilderFactory = KtFileFromResourcesBuilderFactory(packageName.get()),
-            resourceReferenceProvider = ResourceReferenceProvider(resourcesPrefix.get(), themeName.get()),
+            resourceReferenceProvider = ResourceReferenceProvider(
+                resourcesPrefixConfig.get().resourcePrefix,
+                themeName.get(),
+            ),
             namespace = namespace.get(),
-            resPrefix = resourcesPrefix.get(),
+            resPrefixConfig = resourcesPrefixConfig.get(),
             viewThemeParents = viewThemeParents.get(),
             themeName = themeName.get(),
         )
@@ -180,7 +183,12 @@ abstract class GenerateThemeTask : DefaultTask() {
     private val colorGenerator by unsafeLazy {
         generatorFactory.createColorGenerator(colors, palette)
     }
-    private val gradientGenerator by unsafeLazy { generatorFactory.createGradientGenerator(gradients, palette) }
+    private val gradientGenerator by unsafeLazy {
+        generatorFactory.createGradientGenerator(
+            gradients,
+            palette,
+        )
+    }
     private val fontGenerator by unsafeLazy { generatorFactory.createFontGenerator(fonts) }
     private val typographyGenerator by unsafeLazy {
         generatorFactory.createTypographyGenerator(typography)
@@ -224,7 +232,8 @@ abstract class GenerateThemeTask : DefaultTask() {
     }
 
     private fun decodeBase(): Theme =
-        metaFile.get().asFile.decode<Theme>(Serializer.meta).also { logger.debug("decoded base $it") }
+        metaFile.get().asFile.decode<Theme>(Serializer.meta)
+            .also { logger.debug("decoded base $it") }
 
     private val colors: Map<String, String> by unsafeLazy {
         colorFile.get().asFile.decode<Map<String, String>>()

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ResourcePrefixConfig.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ResourcePrefixConfig.kt
@@ -1,0 +1,14 @@
+package com.sdds.plugin.themebuilder
+
+import java.io.Serializable
+
+/**
+ * Конфиг префикса ресурсов
+ *
+ * @property resourcePrefix префикс ресурсов
+ * @property shouldGenerateResPrefixStyle флаг, указывающий на необходимость генерировать стиль с названием префикса.
+ */
+data class ResourcePrefixConfig(
+    val resourcePrefix: String,
+    val shouldGenerateResPrefixStyle: Boolean,
+) : Serializable

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ThemeBuilderPlugin.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ThemeBuilderPlugin.kt
@@ -197,7 +197,7 @@ class ThemeBuilderPlugin : Plugin<Project> {
 
             packageName.set(extension.ktPackage ?: DEFAULT_KT_PACKAGE)
             target.set(extension.target)
-            resourcesPrefix.set(extension.resourcesPrefix ?: project.getDefaultResourcePrefix())
+            resourcesPrefixConfig.set(getResourcePrefixConfig(extension))
             viewThemeParents.set(extension.viewThemeParents)
             generatorMode.set(extension.mode)
             val projectDirProperty = objects.directoryProperty()
@@ -209,6 +209,18 @@ class ThemeBuilderPlugin : Plugin<Project> {
 
             dependsOn(unzipTask)
         }
+    }
+
+    private fun Project.getResourcePrefixConfig(extension: ThemeBuilderExtension): ResourcePrefixConfig {
+        return extension.resourcesPrefix?.let {
+            ResourcePrefixConfig(
+                resourcePrefix = it,
+                shouldGenerateResPrefixStyle = true,
+            )
+        } ?: ResourcePrefixConfig(
+            resourcePrefix = project.getDefaultResourcePrefix(),
+            shouldGenerateResPrefixStyle = false,
+        )
     }
 
     private fun BaseExtension.configureSourceSets() {

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ThemeBuilderPlugin.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ThemeBuilderPlugin.kt
@@ -198,7 +198,7 @@ class ThemeBuilderPlugin : Plugin<Project> {
             packageName.set(extension.ktPackage ?: DEFAULT_KT_PACKAGE)
             target.set(extension.target)
             resourcesPrefix.set(extension.resourcesPrefix ?: project.getDefaultResourcePrefix())
-            parentThemeName.set(extension.parentThemeName)
+            viewThemeParents.set(extension.viewThemeParents)
             generatorMode.set(extension.mode)
             val projectDirProperty = objects.directoryProperty()
                 .apply { set(layout.projectDirectory) }
@@ -206,6 +206,7 @@ class ThemeBuilderPlugin : Plugin<Project> {
             outputDirPath.set(OUTPUT_PATH)
             outputResDirPath.set(OUTPUT_RESOURCE_PATH)
             namespace.set(getProjectNameSpace())
+
             dependsOn(unzipTask)
         }
     }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ViewThemeParent.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/ViewThemeParent.kt
@@ -1,0 +1,38 @@
+package com.sdds.plugin.themebuilder
+
+import java.io.Serializable
+
+/**
+ * Модель наследуемой темы
+ *
+ * @property fullName полное название наследуемой темы
+ * @property childSuffix строка, которую нужно добавить к названию наследника данной темы
+ * @property themeType тип темы (только светлые токены, только темные токены, светлые и темные токены)
+ *
+ * @see [ViewThemeType]
+ */
+data class ViewThemeParent(
+    val fullName: String,
+    val childSuffix: String,
+    val themeType: ViewThemeType = ViewThemeType.DARK_LIGHT,
+) : Serializable
+
+/**
+ * Тип темы
+ */
+enum class ViewThemeType {
+    /**
+     * Дефолтная тема (директория res/values) с темными токенами
+     */
+    DARK,
+
+    /**
+     * Дефолтная тема (директория res/values) со светлыми токенами
+     */
+    LIGHT,
+
+    /**
+     * Дефолтная (директория res/values) и night (директория res/values-night) темы со светлыми и темными токенами
+     */
+    DARK_LIGHT,
+}

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
@@ -1,6 +1,7 @@
 package com.sdds.plugin.themebuilder.internal.factory
 
 import com.sdds.plugin.themebuilder.ThemeBuilderMode
+import com.sdds.plugin.themebuilder.ViewThemeParent
 import com.sdds.plugin.themebuilder.internal.ThemeBuilderTarget
 import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder.OutputLocation
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
@@ -39,7 +40,7 @@ import java.io.File
  * @param resourceReferenceProvider провайдер ссылок на ресурсы
  * @param namespace пакет проекта
  * @param resPrefix префикс для ресурсов
- * @param parentThemeName названий родительской xml-темы
+ * @param viewThemeParents список родительских xml-тем
  * @param themeName название генерируемой темы
  *
  * @author Малышев Александр on 12.03.2024
@@ -60,7 +61,7 @@ internal class GeneratorFactory(
     private val resourceReferenceProvider: ResourceReferenceProvider,
     private val namespace: String,
     private val resPrefix: String,
-    private val parentThemeName: String,
+    private val viewThemeParents: List<ViewThemeParent>,
     private val themeName: String,
 ) {
 
@@ -134,7 +135,7 @@ internal class GeneratorFactory(
         ViewThemeGeneratorFactory(
             xmlResourcesDocumentBuilderFactory,
             outputResDir,
-            parentThemeName,
+            viewThemeParents,
             themeName,
             resPrefix,
         )

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/GeneratorFactory.kt
@@ -1,5 +1,6 @@
 package com.sdds.plugin.themebuilder.internal.factory
 
+import com.sdds.plugin.themebuilder.ResourcePrefixConfig
 import com.sdds.plugin.themebuilder.ThemeBuilderMode
 import com.sdds.plugin.themebuilder.ViewThemeParent
 import com.sdds.plugin.themebuilder.internal.ThemeBuilderTarget
@@ -39,7 +40,7 @@ import java.io.File
  * @param ktFileBuilderFactory фабрика делегата построения kt файлов
  * @param resourceReferenceProvider провайдер ссылок на ресурсы
  * @param namespace пакет проекта
- * @param resPrefix префикс для ресурсов
+ * @param resPrefixConfig конфиг префикса для ресурсов
  * @param viewThemeParents список родительских xml-тем
  * @param themeName название генерируемой темы
  *
@@ -60,7 +61,7 @@ internal class GeneratorFactory(
     private val ktFileFromResourcesBuilderFactory: KtFileFromResourcesBuilderFactory,
     private val resourceReferenceProvider: ResourceReferenceProvider,
     private val namespace: String,
-    private val resPrefix: String,
+    private val resPrefixConfig: ResourcePrefixConfig,
     private val viewThemeParents: List<ViewThemeParent>,
     private val themeName: String,
 ) {
@@ -103,7 +104,7 @@ internal class GeneratorFactory(
         ViewColorAttributeGeneratorFactory(
             xmlDocumentBuilderFactory = xmlResourcesDocumentBuilderFactory,
             outputResDir = outputResDir,
-            attrPrefix = resPrefix,
+            attrPrefix = resPrefixConfig.resourcePrefix,
         )
     }
 
@@ -111,7 +112,7 @@ internal class GeneratorFactory(
         ViewShapeAttributeGeneratorFactory(
             xmlDocumentBuilderFactory = xmlResourcesDocumentBuilderFactory,
             outputResDir = outputResDir,
-            attrPrefix = resPrefix,
+            attrPrefix = resPrefixConfig.resourcePrefix,
         )
     }
 
@@ -119,7 +120,7 @@ internal class GeneratorFactory(
         ViewTypographyAttributeGeneratorFactory(
             xmlDocumentBuilderFactory = xmlResourcesDocumentBuilderFactory,
             outputResDir = outputResDir,
-            attrPrefix = resPrefix,
+            attrPrefix = resPrefixConfig.resourcePrefix,
         )
     }
 
@@ -137,7 +138,7 @@ internal class GeneratorFactory(
             outputResDir,
             viewThemeParents,
             themeName,
-            resPrefix,
+            resPrefixConfig,
         )
     }
 
@@ -228,7 +229,7 @@ internal class GeneratorFactory(
             fontDownloaderFactory,
             ktFileBuilderFactory,
             namespace,
-            resPrefix,
+            resPrefixConfig.resourcePrefix,
             fonts,
             fontsAggregator,
         )

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/ViewThemeGeneratorFactory.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/ViewThemeGeneratorFactory.kt
@@ -1,5 +1,6 @@
 package com.sdds.plugin.themebuilder.internal.factory
 
+import com.sdds.plugin.themebuilder.ViewThemeParent
 import com.sdds.plugin.themebuilder.internal.generator.theme.view.ViewThemeGenerator
 import java.io.File
 
@@ -9,7 +10,7 @@ import java.io.File
 internal class ViewThemeGeneratorFactory(
     private val xmlResourcesDocumentBuilderFactory: XmlResourcesDocumentBuilderFactory,
     private val outputResDir: File,
-    private val parentThemeName: String,
+    private val viewThemeParents: List<ViewThemeParent>,
     private val themeName: String,
     private val resPrefix: String,
 ) {
@@ -21,7 +22,7 @@ internal class ViewThemeGeneratorFactory(
         ViewThemeGenerator(
             xmlBuilderFactory = xmlResourcesDocumentBuilderFactory,
             outputResDir = outputResDir,
-            parentThemeName = parentThemeName,
+            viewThemeParents = viewThemeParents,
             themeName = themeName,
             resPrefix = resPrefix,
         )

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/ViewThemeGeneratorFactory.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/factory/ViewThemeGeneratorFactory.kt
@@ -1,5 +1,6 @@
 package com.sdds.plugin.themebuilder.internal.factory
 
+import com.sdds.plugin.themebuilder.ResourcePrefixConfig
 import com.sdds.plugin.themebuilder.ViewThemeParent
 import com.sdds.plugin.themebuilder.internal.generator.theme.view.ViewThemeGenerator
 import java.io.File
@@ -12,7 +13,7 @@ internal class ViewThemeGeneratorFactory(
     private val outputResDir: File,
     private val viewThemeParents: List<ViewThemeParent>,
     private val themeName: String,
-    private val resPrefix: String,
+    private val resPrefixConfig: ResourcePrefixConfig,
 ) {
 
     /**
@@ -24,6 +25,6 @@ internal class ViewThemeGeneratorFactory(
             outputResDir = outputResDir,
             viewThemeParents = viewThemeParents,
             themeName = themeName,
-            resPrefix = resPrefix,
+            resPrefixConfig = resPrefixConfig,
         )
 }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewThemeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/view/ViewThemeGenerator.kt
@@ -1,5 +1,6 @@
 package com.sdds.plugin.themebuilder.internal.generator.theme.view
 
+import com.sdds.plugin.themebuilder.ResourcePrefixConfig
 import com.sdds.plugin.themebuilder.ViewThemeParent
 import com.sdds.plugin.themebuilder.ViewThemeType
 import com.sdds.plugin.themebuilder.internal.builder.XmlResourcesDocumentBuilder
@@ -23,7 +24,7 @@ import java.io.File
  * @property xmlBuilderFactory фабрика [XmlResourcesDocumentBuilder]
  * @property outputResDir директория для xml-ресурсов
  * @property viewThemeParents список тем, от которых необходимо унаследовать генерируемые темы
- * @param resPrefix префикс ресурсов
+ * @property resPrefixConfig префикс ресурсов
  * @param themeName название темы
  *
  * @see ViewThemeType
@@ -33,7 +34,7 @@ internal class ViewThemeGenerator(
     private val xmlBuilderFactory: XmlResourcesDocumentBuilderFactory,
     private val outputResDir: File,
     private val viewThemeParents: List<ViewThemeParent>,
-    resPrefix: String,
+    private val resPrefixConfig: ResourcePrefixConfig,
     themeName: String,
 ) : SimpleBaseGenerator {
 
@@ -53,7 +54,7 @@ internal class ViewThemeGenerator(
         xmlBuilderFactory.create()
     }
 
-    private val capitalizedResPrefix = resPrefix.capitalized()
+    private val capitalizedResPrefix = resPrefixConfig.resourcePrefix.capitalized()
     private val camelCaseThemeName = themeName.snakeToCamelCase()
 
     internal fun setColorTokenData(data: ColorTokenResult.TokenData) {
@@ -108,7 +109,9 @@ internal class ViewThemeGenerator(
     }
 
     private fun collectEmptyBaseStyles() {
-        emptyStylesCollector.add(capitalizedResPrefix)
+        if (resPrefixConfig.shouldGenerateResPrefixStyle) {
+            emptyStylesCollector.add(capitalizedResPrefix)
+        }
         emptyStylesCollector.add("$capitalizedResPrefix.$camelCaseThemeName")
     }
 

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/config/ViewConfigBuilderTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/config/ViewConfigBuilderTest.kt
@@ -1,0 +1,57 @@
+package com.sdds.plugin.themebuilder.internal.config
+
+import com.sdds.plugin.themebuilder.ViewConfigBuilder
+import com.sdds.plugin.themebuilder.ViewThemeParent
+import com.sdds.plugin.themebuilder.ViewThemeType
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit-тесты [ViewConfigBuilder]
+ */
+class ViewConfigBuilderTest {
+
+    private lateinit var underTest: ViewConfigBuilder
+
+    @Before
+    fun setup() {
+        underTest = ViewConfigBuilder()
+    }
+
+    @Test
+    fun `ViewConfigBuilder должен вернуть пустой сет`() {
+        underTest.themeParents {}
+        assertEquals(emptySet<ViewThemeParent>(), underTest.themeParents)
+    }
+
+    @Test
+    fun `ViewConfigBuilder должен вернуть корректный сет`() {
+        underTest.themeParents {
+            materialComponentsTheme()
+            appCompatTheme("Light")
+            customTheme("App.Theme.Custom")
+        }
+        assertEquals(validData, underTest.themeParents)
+    }
+
+    private companion object {
+        val validData = setOf(
+            ViewThemeParent(
+                fullName = "Theme.MaterialComponents",
+                childSuffix = "MaterialComponents",
+                themeType = ViewThemeType.DARK,
+            ),
+            ViewThemeParent(
+                fullName = "Theme.AppCompat.Light",
+                childSuffix = "AppCompat.Light",
+                themeType = ViewThemeType.LIGHT,
+            ),
+            ViewThemeParent(
+                fullName = "App.Theme.Custom",
+                childSuffix = "App.Theme.Custom",
+                themeType = ViewThemeType.DARK_LIGHT,
+            ),
+        )
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/config/ViewParentListBuilderTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/config/ViewParentListBuilderTest.kt
@@ -1,0 +1,89 @@
+package com.sdds.plugin.themebuilder.internal.config
+
+import com.sdds.plugin.themebuilder.ViewParentListBuilder
+import com.sdds.plugin.themebuilder.ViewThemeParent
+import com.sdds.plugin.themebuilder.ViewThemeType
+import com.sdds.plugin.themebuilder.internal.exceptions.ThemeBuilderException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit-тесты [ViewParentListBuilder]
+ */
+class ViewParentListBuilderTest {
+
+    private lateinit var underTest: ViewParentListBuilder
+
+    @Before
+    fun setup() {
+        underTest = ViewParentListBuilder()
+    }
+
+    @Test
+    fun `ViewParentListBuilder должен выбросить исключение`() {
+        assertThrows(ThemeBuilderException::class.java) {
+            underTest.customTheme("")
+        }
+    }
+
+    @Test
+    fun `ViewParentListBuilder должен вернуть корректный сет`() {
+        underTest.materialComponentsTheme()
+        underTest.materialComponentsTheme("DayNight.DarkActionBar")
+        underTest.materialComponentsTheme("NoActionBar")
+        underTest.materialComponentsTheme("Light.Bridge")
+        underTest.appCompatTheme()
+        underTest.appCompatTheme("Light")
+        underTest.appCompatTheme("Light.NoDialog")
+        underTest.customTheme("App.Theme.Custom")
+
+        assertEquals(validData, underTest.themeParents)
+    }
+
+    private companion object {
+        val validData = setOf(
+            ViewThemeParent(
+                fullName = "Theme.MaterialComponents",
+                childSuffix = "MaterialComponents",
+                themeType = ViewThemeType.DARK,
+            ),
+            ViewThemeParent(
+                fullName = "Theme.MaterialComponents.DayNight.DarkActionBar",
+                childSuffix = "MaterialComponents.DayNight.DarkActionBar",
+                themeType = ViewThemeType.DARK_LIGHT,
+            ),
+            ViewThemeParent(
+                fullName = "Theme.MaterialComponents.NoActionBar",
+                childSuffix = "MaterialComponents.NoActionBar",
+                themeType = ViewThemeType.DARK,
+            ),
+            ViewThemeParent(
+                fullName = "Theme.MaterialComponents.Light.Bridge",
+                childSuffix = "MaterialComponents.Light.Bridge",
+                themeType = ViewThemeType.LIGHT,
+            ),
+            ViewThemeParent(
+                fullName = "Theme.AppCompat",
+                childSuffix = "AppCompat",
+                themeType = ViewThemeType.DARK,
+            ),
+            ViewThemeParent(
+                fullName = "Theme.AppCompat.Light",
+                childSuffix = "AppCompat.Light",
+                themeType = ViewThemeType.LIGHT,
+            ),
+            ViewThemeParent(
+                fullName = "Theme.AppCompat.Light.NoDialog",
+                childSuffix = "AppCompat.Light.NoDialog",
+                themeType = ViewThemeType.LIGHT,
+            ),
+            ViewThemeParent(
+                fullName = "App.Theme.Custom",
+                childSuffix = "App.Theme.Custom",
+                themeType = ViewThemeType.DARK_LIGHT,
+            ),
+        )
+    }
+}

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
@@ -1,5 +1,7 @@
 package com.sdds.plugin.themebuilder.internal.generator.theme
 
+import com.sdds.plugin.themebuilder.ViewThemeParent
+import com.sdds.plugin.themebuilder.ViewThemeType
 import com.sdds.plugin.themebuilder.internal.factory.XmlResourcesDocumentBuilderFactory
 import com.sdds.plugin.themebuilder.internal.generator.data.ColorTokenResult
 import com.sdds.plugin.themebuilder.internal.generator.data.ShapeTokenResult
@@ -16,8 +18,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -39,14 +42,6 @@ class ViewThemeGeneratorTest {
             FileProvider,
         )
         mockOutputResDir = mockk(relaxed = true)
-
-        underTest = ViewThemeGenerator(
-            xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr", "TestTheme"),
-            outputResDir = mockOutputResDir,
-            parentThemeName = "Sdds.Theme",
-            themeName = "test_Theme",
-            resPrefix = "thmbldr",
-        )
     }
 
     @After
@@ -60,7 +55,15 @@ class ViewThemeGeneratorTest {
     }
 
     @Test
-    fun `ViewThemeGenerator генерирует тему`() {
+    fun `ViewThemeGenerator генерирует дефолтную и night тему без наследников`() {
+        underTest = ViewThemeGenerator(
+            xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr", "TestTheme"),
+            outputResDir = mockOutputResDir,
+            viewThemeParents = emptyList(),
+            themeName = "test_Theme",
+            resPrefix = "thmbldr",
+        )
+
         val lightOutputXml = ByteArrayOutputStream()
         val darkOutputXml = ByteArrayOutputStream()
 
@@ -78,12 +81,174 @@ class ViewThemeGeneratorTest {
         underTest.setTypographyTokenData(typographyAttrs)
         underTest.generate()
 
-        Assert.assertEquals(
+        assertEquals(
             getResourceAsText("theme-outputs/test-theme-output.xml"),
             lightOutputXml.toString(),
         )
-        Assert.assertEquals(
+        assertEquals(
             getResourceAsText("theme-outputs/test-dark-theme-output.xml"),
+            darkOutputXml.toString(),
+        )
+    }
+
+    @Test
+    fun `ViewThemeGenerator генерирует дефолтную и night тему наследуясь от Material темы`() {
+        underTest = ViewThemeGenerator(
+            xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr", "TestTheme"),
+            outputResDir = mockOutputResDir,
+            viewThemeParents = listOf(
+                ViewThemeParent(
+                    "Theme.MaterialComponents.DayNight",
+                    "MaterialComponents.DayNight",
+                    ViewThemeType.DARK_LIGHT,
+                ),
+            ),
+            themeName = "test_Theme",
+            resPrefix = "thmbldr",
+        )
+
+        val lightOutputXml = ByteArrayOutputStream()
+        val darkOutputXml = ByteArrayOutputStream()
+
+        val themeLightXmlFile = mockk<File>(relaxed = true)
+        val themeDarkXmlFile = mockk<File>(relaxed = true)
+
+        every { themeLightXmlFile.fileWriter() } returns lightOutputXml.writer()
+        every { themeDarkXmlFile.fileWriter() } returns darkOutputXml.writer()
+
+        every { mockOutputResDir.themeXmlFile() } returns themeLightXmlFile
+        every { mockOutputResDir.themeXmlFile("night") } returns themeDarkXmlFile
+
+        underTest.setShapeTokenData(shapeAttrs)
+        underTest.setColorTokenData(colorAttrs)
+        underTest.setTypographyTokenData(typographyAttrs)
+        underTest.generate()
+
+        assertEquals(
+            getResourceAsText("theme-outputs/test-material-daynight-theme-output.xml"),
+            lightOutputXml.toString(),
+        )
+        assertEquals(
+            getResourceAsText("theme-outputs/test-material-daynight-dark-theme-output.xml"),
+            darkOutputXml.toString(),
+        )
+    }
+
+    @Test
+    fun `ViewThemeGenerator генерирует только дефолтную тему с темными токенами наследуясь от Material темы`() {
+        underTest = ViewThemeGenerator(
+            xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr", "TestTheme"),
+            outputResDir = mockOutputResDir,
+            viewThemeParents = listOf(
+                ViewThemeParent(
+                    "Theme.MaterialComponents",
+                    "MaterialComponents",
+                    ViewThemeType.DARK,
+                ),
+            ),
+            themeName = "test_Theme",
+            resPrefix = "thmbldr",
+        )
+
+        val lightOutputXml = ByteArrayOutputStream()
+        val themeLightXmlFile = mockk<File>(relaxed = true)
+        every { themeLightXmlFile.fileWriter() } returns lightOutputXml.writer()
+        every { mockOutputResDir.themeXmlFile() } returns themeLightXmlFile
+
+        underTest.setShapeTokenData(shapeAttrs)
+        underTest.setColorTokenData(colorAttrs)
+        underTest.setTypographyTokenData(typographyAttrs)
+        underTest.generate()
+
+        verify(exactly = 0) { mockOutputResDir.themeXmlFile("night") }
+
+        assertEquals(
+            getResourceAsText("theme-outputs/test-material-dark-theme-output.xml"),
+            lightOutputXml.toString(),
+        )
+    }
+
+    @Test
+    fun `ViewThemeGenerator генерирует только дефолтную тему со светлыми токенами наследуясь от Material темы`() {
+        underTest = ViewThemeGenerator(
+            xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr", "TestTheme"),
+            outputResDir = mockOutputResDir,
+            viewThemeParents = listOf(
+                ViewThemeParent(
+                    "Theme.MaterialComponents.Light.NoDialog",
+                    "MaterialComponents.Light.NoDialog",
+                    ViewThemeType.LIGHT,
+                ),
+            ),
+            themeName = "test_Theme",
+            resPrefix = "thmbldr",
+        )
+
+        val lightOutputXml = ByteArrayOutputStream()
+        val themeLightXmlFile = mockk<File>(relaxed = true)
+        every { themeLightXmlFile.fileWriter() } returns lightOutputXml.writer()
+        every { mockOutputResDir.themeXmlFile() } returns themeLightXmlFile
+
+        underTest.setShapeTokenData(shapeAttrs)
+        underTest.setColorTokenData(colorAttrs)
+        underTest.setTypographyTokenData(typographyAttrs)
+        underTest.generate()
+
+        verify(exactly = 0) { mockOutputResDir.themeXmlFile("night") }
+
+        assertEquals(
+            getResourceAsText("theme-outputs/test-material-light-theme-output.xml"),
+            lightOutputXml.toString(),
+        )
+    }
+
+    @Test
+    fun `ViewThemeGenerator генерирует несколько тем без конфликтов промежуточных стилей`() {
+        underTest = ViewThemeGenerator(
+            xmlBuilderFactory = XmlResourcesDocumentBuilderFactory("thmbldr", "TestTheme"),
+            outputResDir = mockOutputResDir,
+            viewThemeParents = listOf(
+                ViewThemeParent(
+                    "Theme.MaterialComponents.Light.NoDialog",
+                    "MaterialComponents.Light.NoDialog",
+                    ViewThemeType.LIGHT,
+                ),
+                ViewThemeParent(
+                    "Theme.MaterialComponents.DayNight",
+                    "MaterialComponents.DayNight",
+                    ViewThemeType.DARK_LIGHT,
+                ),
+                ViewThemeParent(
+                    "Theme.AppCompat.DayNight",
+                    "AppCompat.DayNight",
+                    ViewThemeType.DARK_LIGHT,
+                ),
+            ),
+            themeName = "test_Theme",
+            resPrefix = "thmbldr",
+        )
+
+        val lightOutputXml = ByteArrayOutputStream()
+        val darkOutputXml = ByteArrayOutputStream()
+        val themeLightXmlFile = mockk<File>(relaxed = true)
+        val themeDarkXmlFile = mockk<File>(relaxed = true)
+        every { themeLightXmlFile.fileWriter() } returns lightOutputXml.writer()
+        every { themeDarkXmlFile.fileWriter() } returns darkOutputXml.writer()
+        every { mockOutputResDir.themeXmlFile() } returns themeLightXmlFile
+        every { mockOutputResDir.themeXmlFile("night") } returns themeDarkXmlFile
+
+        underTest.setShapeTokenData(shapeAttrs)
+        underTest.setColorTokenData(colorAttrs)
+        underTest.setTypographyTokenData(typographyAttrs)
+        underTest.generate()
+
+        assertEquals(
+            getResourceAsText("theme-outputs/test-many-daynight-theme-output.xml"),
+            lightOutputXml.toString(),
+        )
+
+        assertEquals(
+            getResourceAsText("theme-outputs/test-many-daynight-dark-theme-output.xml"),
             darkOutputXml.toString(),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/ViewThemeGeneratorTest.kt
@@ -1,5 +1,6 @@
 package com.sdds.plugin.themebuilder.internal.generator.theme
 
+import com.sdds.plugin.themebuilder.ResourcePrefixConfig
 import com.sdds.plugin.themebuilder.ViewThemeParent
 import com.sdds.plugin.themebuilder.ViewThemeType
 import com.sdds.plugin.themebuilder.internal.factory.XmlResourcesDocumentBuilderFactory
@@ -61,7 +62,10 @@ class ViewThemeGeneratorTest {
             outputResDir = mockOutputResDir,
             viewThemeParents = emptyList(),
             themeName = "test_Theme",
-            resPrefix = "thmbldr",
+            resPrefixConfig = ResourcePrefixConfig(
+                resourcePrefix = "thmbldr",
+                shouldGenerateResPrefixStyle = true,
+            ),
         )
 
         val lightOutputXml = ByteArrayOutputStream()
@@ -104,7 +108,10 @@ class ViewThemeGeneratorTest {
                 ),
             ),
             themeName = "test_Theme",
-            resPrefix = "thmbldr",
+            resPrefixConfig = ResourcePrefixConfig(
+                resourcePrefix = "thmbldr",
+                shouldGenerateResPrefixStyle = true,
+            ),
         )
 
         val lightOutputXml = ByteArrayOutputStream()
@@ -147,7 +154,10 @@ class ViewThemeGeneratorTest {
                 ),
             ),
             themeName = "test_Theme",
-            resPrefix = "thmbldr",
+            resPrefixConfig = ResourcePrefixConfig(
+                resourcePrefix = "thmbldr",
+                shouldGenerateResPrefixStyle = true,
+            ),
         )
 
         val lightOutputXml = ByteArrayOutputStream()
@@ -181,7 +191,10 @@ class ViewThemeGeneratorTest {
                 ),
             ),
             themeName = "test_Theme",
-            resPrefix = "thmbldr",
+            resPrefixConfig = ResourcePrefixConfig(
+                resourcePrefix = "thmbldr",
+                shouldGenerateResPrefixStyle = true,
+            ),
         )
 
         val lightOutputXml = ByteArrayOutputStream()
@@ -225,7 +238,10 @@ class ViewThemeGeneratorTest {
                 ),
             ),
             themeName = "test_Theme",
-            resPrefix = "thmbldr",
+            resPrefixConfig = ResourcePrefixConfig(
+                resourcePrefix = "thmbldr",
+                shouldGenerateResPrefixStyle = true,
+            ),
         )
 
         val lightOutputXml = ByteArrayOutputStream()

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-many-daynight-dark-theme-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-many-daynight-dark-theme-output.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<resources>
+    <style name="Thmbldr.TestTheme.MaterialComponents.DayNight" parent="Theme.MaterialComponents.DayNight">
+        <!--Dark colors-->
+        <item name="thmbldr_textPrimary">@color/thmbldr_dark_text_primary</item>
+    </style>
+    <style name="Thmbldr.TestTheme.AppCompat.DayNight" parent="Theme.AppCompat.DayNight">
+        <!--Dark colors-->
+        <item name="thmbldr_textPrimary">@color/thmbldr_dark_text_primary</item>
+    </style>
+</resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-many-daynight-theme-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-many-daynight-theme-output.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<resources>
+    <style name="Thmbldr.TestTheme.MaterialComponents.Light.NoDialog" parent="Theme.MaterialComponents.Light.NoDialog">
+        <!--Light colors-->
+        <item name="thmbldr_textPrimary">@color/thmbldr_light_text_primary</item>
+        <!--Shapes-->
+        <item name="thmbldr_shapeRoundXs">@style/Thmbldr.TestTheme.Shape.Round.Xs</item>
+        <item name="thmbldr_shapeRoundXxs">@style/Thmbldr.TestTheme.Shape.Round.Xxs</item>
+        <!--Typography-->
+        <item name="thmbldr_typographyDisplayLNormal">@style/Thmbldr.TestTheme.Typography.DisplayLNormal</item>
+        <item name="thmbldr_typographyHeaderH3Bold">@style/Thmbldr.TestTheme.Typography.HeaderH3Bold</item>
+    </style>
+    <style name="Thmbldr.TestTheme.MaterialComponents.DayNight" parent="Theme.MaterialComponents.DayNight">
+        <!--Light colors-->
+        <item name="thmbldr_textPrimary">@color/thmbldr_light_text_primary</item>
+        <!--Shapes-->
+        <item name="thmbldr_shapeRoundXs">@style/Thmbldr.TestTheme.Shape.Round.Xs</item>
+        <item name="thmbldr_shapeRoundXxs">@style/Thmbldr.TestTheme.Shape.Round.Xxs</item>
+        <!--Typography-->
+        <item name="thmbldr_typographyDisplayLNormal">@style/Thmbldr.TestTheme.Typography.DisplayLNormal</item>
+        <item name="thmbldr_typographyHeaderH3Bold">@style/Thmbldr.TestTheme.Typography.HeaderH3Bold</item>
+    </style>
+    <style name="Thmbldr.TestTheme.AppCompat.DayNight" parent="Theme.AppCompat.DayNight">
+        <!--Light colors-->
+        <item name="thmbldr_textPrimary">@color/thmbldr_light_text_primary</item>
+        <!--Shapes-->
+        <item name="thmbldr_shapeRoundXs">@style/Thmbldr.TestTheme.Shape.Round.Xs</item>
+        <item name="thmbldr_shapeRoundXxs">@style/Thmbldr.TestTheme.Shape.Round.Xxs</item>
+        <!--Typography-->
+        <item name="thmbldr_typographyDisplayLNormal">@style/Thmbldr.TestTheme.Typography.DisplayLNormal</item>
+        <item name="thmbldr_typographyHeaderH3Bold">@style/Thmbldr.TestTheme.Typography.HeaderH3Bold</item>
+    </style>
+    <style name="Thmbldr.TestTheme.MaterialComponents"/>
+    <style name="Thmbldr.TestTheme.MaterialComponents.Light"/>
+    <style name="Thmbldr.TestTheme.AppCompat"/>
+    <style name="Thmbldr"/>
+    <style name="Thmbldr.TestTheme"/>
+</resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-dark-theme-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-dark-theme-output.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources>
-    <style name="Thmbldr.TestTheme">
-        <!--Light colors-->
-        <item name="thmbldr_textPrimary">@color/thmbldr_light_text_primary</item>
+    <style name="Thmbldr.TestTheme.MaterialComponents" parent="Theme.MaterialComponents">
+        <!--Dark colors-->
+        <item name="thmbldr_textPrimary">@color/thmbldr_dark_text_primary</item>
         <!--Shapes-->
         <item name="thmbldr_shapeRoundXs">@style/Thmbldr.TestTheme.Shape.Round.Xs</item>
         <item name="thmbldr_shapeRoundXxs">@style/Thmbldr.TestTheme.Shape.Round.Xxs</item>
@@ -11,4 +11,5 @@
         <item name="thmbldr_typographyHeaderH3Bold">@style/Thmbldr.TestTheme.Typography.HeaderH3Bold</item>
     </style>
     <style name="Thmbldr"/>
+    <style name="Thmbldr.TestTheme"/>
 </resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-daynight-dark-theme-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-daynight-dark-theme-output.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources>
-    <style name="Thmbldr.TestTheme">
+    <style name="Thmbldr.TestTheme.MaterialComponents.DayNight" parent="Theme.MaterialComponents.DayNight">
         <!--Dark colors-->
         <item name="thmbldr_textPrimary">@color/thmbldr_dark_text_primary</item>
     </style>

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-daynight-theme-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-daynight-theme-output.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources>
-    <style name="Thmbldr.TestTheme">
+    <style name="Thmbldr.TestTheme.MaterialComponents.DayNight" parent="Theme.MaterialComponents.DayNight">
         <!--Light colors-->
         <item name="thmbldr_textPrimary">@color/thmbldr_light_text_primary</item>
         <!--Shapes-->
@@ -10,5 +10,7 @@
         <item name="thmbldr_typographyDisplayLNormal">@style/Thmbldr.TestTheme.Typography.DisplayLNormal</item>
         <item name="thmbldr_typographyHeaderH3Bold">@style/Thmbldr.TestTheme.Typography.HeaderH3Bold</item>
     </style>
+    <style name="Thmbldr.TestTheme.MaterialComponents"/>
     <style name="Thmbldr"/>
+    <style name="Thmbldr.TestTheme"/>
 </resources>

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-light-theme-output.xml
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/test-material-light-theme-output.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources>
-    <style name="Thmbldr.TestTheme">
+    <style name="Thmbldr.TestTheme.MaterialComponents.Light.NoDialog" parent="Theme.MaterialComponents.Light.NoDialog">
         <!--Light colors-->
         <item name="thmbldr_textPrimary">@color/thmbldr_light_text_primary</item>
         <!--Shapes-->
@@ -10,5 +10,8 @@
         <item name="thmbldr_typographyDisplayLNormal">@style/Thmbldr.TestTheme.Typography.DisplayLNormal</item>
         <item name="thmbldr_typographyHeaderH3Bold">@style/Thmbldr.TestTheme.Typography.HeaderH3Bold</item>
     </style>
+    <style name="Thmbldr.TestTheme.MaterialComponents"/>
+    <style name="Thmbldr.TestTheme.MaterialComponents.Light"/>
     <style name="Thmbldr"/>
+    <style name="Thmbldr.TestTheme"/>
 </resources>


### PR DESCRIPTION
* Реализовал возможность генерации тем view, наследуясь от любых тем
* Исправил проблему конфликта стиля, у которого название состоит из resPrefix. Если он указан в AGP, то ожидаем, что этот стиль объявлен у клиента. Если resPrefix в конфиге themeBuilder, то генерируем этот стиль сами.