### PR TITLE
test(sdds-acore/sandbox): VS button, compose textfield and chip screenshot tests

### DIFF
--- a/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/buttons/SandboxButton.kt
+++ b/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/buttons/SandboxButton.kt
@@ -164,7 +164,7 @@ internal fun SandboxButtonPreviewSizeXSDefault() {
         size = SandboxButton.Size.XS,
         style = SandboxButton.Style.Default,
         label = "Label",
-        value = "Valuel",
+        value = "Value",
         enabled = true,
         loading = false,
         onClick = {},
@@ -241,6 +241,22 @@ internal fun SandboxButtonPreviewSizeSWarning() {
         size = SandboxButton.Size.S,
         style = SandboxButton.Style.Warning,
         label = "Label",
+        enabled = true,
+        loading = false,
+        onClick = {},
+    )
+}
+
+@Composable
+@Preview
+internal fun SandboxButtonPreviewSizeXsBlack() {
+    SandboxBasicButton(
+        icons = Button.Icons(end = painterResource(id = R.drawable.ic_plasma_24)),
+        spacing = Button.Spacing.SpaceBetween,
+        size = SandboxButton.Size.XS,
+        style = SandboxButton.Style.Black,
+        label = "Label",
+        value = "Value",
         enabled = true,
         loading = false,
         onClick = {},

--- a/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/chip/SandboxChip.kt
+++ b/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/chip/SandboxChip.kt
@@ -5,9 +5,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sdds.compose.uikit.Chip
+import com.sdds.compose.uikit.Icon
+import com.sdds.playground.sandbox.SandboxTheme
 import com.sdds.playground.sandbox.chip.SandboxChipSettingsProvider.backgroundColor
 import com.sdds.playground.sandbox.chip.SandboxChipSettingsProvider.contentColor
 import com.sdds.playground.sandbox.chip.SandboxChipSettingsProvider.contentMargin
@@ -109,5 +113,101 @@ internal object SandboxChip {
         M(40.dp),
         S(32.dp),
         XS(24.dp),
+    }
+}
+
+@Composable
+@Preview
+internal fun SandboxChipPreviewSizeMDefault() {
+    SandboxTheme {
+        SandboxChip(
+            size = SandboxChip.Size.L,
+            shape = SandboxChip.Shape.Default,
+            state = SandboxChip.State.Default,
+            label = "Label",
+            onClick = {},
+            startContent = {
+                Icon(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_plasma_24),
+                    contentDescription = null,
+                )
+            },
+            endContent = {
+                Icon(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_close_24),
+                    contentDescription = null,
+                )
+            },
+            enabled = true,
+        )
+    }
+}
+
+@Composable
+@Preview
+internal fun SandboxChipPreviewSizeXsSecondary() {
+    SandboxTheme(darkTheme = true) {
+        SandboxChip(
+            size = SandboxChip.Size.XS,
+            shape = SandboxChip.Shape.Default,
+            state = SandboxChip.State.Secondary,
+            label = "Label",
+            onClick = {},
+            startContent = {
+                Icon(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_plasma_24),
+                    contentDescription = null,
+                )
+            },
+            endContent = {
+                Icon(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_close_24),
+                    contentDescription = null,
+                )
+            },
+            enabled = true,
+        )
+    }
+}
+
+@Composable
+@Preview
+internal fun SandboxChipPreviewSizeMAccent() {
+    SandboxTheme {
+        SandboxChip(
+            size = SandboxChip.Size.M,
+            shape = SandboxChip.Shape.Pilled,
+            state = SandboxChip.State.Accent,
+            label = "Label",
+            onClick = {},
+            enabled = true,
+        )
+    }
+}
+
+@Composable
+@Preview
+internal fun SandboxChipPreviewSizeSDisabled() {
+    SandboxTheme {
+        SandboxChip(
+            size = SandboxChip.Size.S,
+            shape = SandboxChip.Shape.Default,
+            state = SandboxChip.State.Default,
+            label = "Label",
+            onClick = {},
+            startContent = {
+                Icon(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_plasma_24),
+                    contentDescription = null,
+                )
+            },
+            endContent = {
+                Icon(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_close_24),
+                    contentDescription = null,
+                )
+            },
+            enabled = false,
+        )
     }
 }

--- a/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/textfield/SandboxTextField.kt
+++ b/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/textfield/SandboxTextField.kt
@@ -233,3 +233,355 @@ fun SandboxTextFieldPreview() {
         )
     }
 }
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewXsError() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Outer,
+            size = Size.XS,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_16),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_16),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Error,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewLSuccess() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "Optional",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Outer,
+            size = Size.L,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Success,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewMWarning() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Outer,
+            size = Size.M,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Warning,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewInner() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Inner,
+            size = Size.L,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Default,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewLInactive() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Inner,
+            size = Size.L,
+            onValueChange = {},
+            enabled = false,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Default,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewSDefault() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Outer,
+            fieldType = SandboxTextField.FieldType.Optional,
+            size = Size.S,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Default,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewLReadOnly() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Outer,
+            size = Size.L,
+            onValueChange = {},
+            enabled = true,
+            readOnly = true,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Default,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewLPlaceholder() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = ""),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Outer,
+            size = Size.L,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Default,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewHasDot() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Outer,
+            fieldType = SandboxTextField.FieldType.Required,
+            size = Size.L,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.Start,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Default,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun SandboxTextFieldPreviewHasDotInsideEnd() {
+    SandboxTheme {
+        SandboxTextField(
+            value = TextFieldValue(text = "Value"),
+            captionText = "Сaption",
+            labelText = "Label",
+            optionalText = "",
+            placeholderText = "Placeholder",
+            labelType = LabelType.Inner,
+            fieldType = SandboxTextField.FieldType.Required,
+            size = Size.M,
+            onValueChange = {},
+            enabled = true,
+            readOnly = false,
+            dotBadgePosition = DotBadge.Position.End,
+            leadingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            trailingIcon = {
+                Image(
+                    painter = painterResource(id = com.sdds.icons.R.drawable.ic_lock_fill_24),
+                    contentDescription = "",
+                    colorFilter = ColorFilter.tint(Color.Black),
+                )
+            },
+            state = State.Default,
+        )
+    }
+}

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeButtonScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeButtonScreenshotTest.kt
@@ -1,6 +1,7 @@
+package com.sdds.playground.sandbox
+
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.sdds.playground.sandbox.SandboxTheme
 import com.sdds.playground.sandbox.buttons.SandboxButtonPreviewSizeLDefault
 import com.sdds.playground.sandbox.buttons.SandboxButtonPreviewSizeLPositive
 import com.sdds.playground.sandbox.buttons.SandboxButtonPreviewSizeLWhiteDarkTheme

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeCheckBoxScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeCheckBoxScreenshotTest.kt
@@ -1,6 +1,7 @@
+package com.sdds.playground.sandbox
+
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.sdds.playground.sandbox.SandboxTheme
 import com.sdds.playground.sandbox.checkbox.SandboxCheckBoxPreviewCheckedSizeSmall
 import com.sdds.playground.sandbox.checkbox.SandboxCheckBoxPreviewOffSizeSmall
 import com.sdds.playground.sandbox.checkbox.SandboxCheckBoxPreviewOnSizeMediumNoDesc

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeChipScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeChipScreenshotTest.kt
@@ -1,0 +1,66 @@
+package com.sdds.playground.sandbox
+
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.sdds.playground.sandbox.chip.SandboxChipPreviewSizeMAccent
+import com.sdds.playground.sandbox.chip.SandboxChipPreviewSizeMDefault
+import com.sdds.playground.sandbox.chip.SandboxChipPreviewSizeSDisabled
+import com.sdds.playground.sandbox.chip.SandboxChipPreviewSizeXsSecondary
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [SDK_NUMBER], qualifiers = RobolectricDeviceQualifiers.Pixel6)
+@RunWith(RobolectricTestRunner::class)
+class ComposeChipScreenshotTest {
+
+    private val config = RoborazziConfig()
+
+    /**
+     * Для запуска только скриншот тестов
+     */
+    interface ScreenshotTests
+
+    /**
+     * Запуск скриншот тестов с использованием Preview
+     */
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testChipPreviewSizeMDefault() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxChipPreviewSizeMDefault()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testChipPreviewSizeXsSecondary() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxChipPreviewSizeXsSecondary()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testChipPreviewSizeMAccent() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxChipPreviewSizeMAccent()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testChipPreviewSizeSDisabled() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxChipPreviewSizeSDisabled()
+        }
+    }
+}

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeProgressBarScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeProgressBarScreenshotTest.kt
@@ -1,3 +1,5 @@
+package com.sdds.playground.sandbox
+
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.sdds.playground.sandbox.progress.SandboxProgressPreviewDefaultTheme
@@ -26,7 +28,7 @@ class ComposeProgressBarScreenshotTest {
      */
     @Category(ScreenshotTests::class)
     @Test
-    internal fun testProgressBarPreviewDefault() {
+    fun testProgressBarPreviewDefault() {
         captureRoboImage {
             config.roborazziOptions
             SandboxProgressPreviewDefaultTheme()
@@ -35,7 +37,7 @@ class ComposeProgressBarScreenshotTest {
 
     @Category(ScreenshotTests::class)
     @Test
-    internal fun testProgressBarWarning() {
+    fun testProgressBarWarning() {
         captureRoboImage {
             config.roborazziOptions
             SandboxProgressPreviewWarningTheme()

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeRadioBoxScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeRadioBoxScreenshotTest.kt
@@ -1,6 +1,7 @@
+package com.sdds.playground.sandbox
+
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.sdds.playground.sandbox.SandboxTheme
 import com.sdds.playground.sandbox.radiobox.SandboxRadioBoxPreviewMedium
 import com.sdds.playground.sandbox.radiobox.SandboxRadioBoxPreviewOff
 import com.sdds.playground.sandbox.radiobox.SandboxRadioBoxPreviewSmallDark

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeSwitchScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeSwitchScreenshotTest.kt
@@ -1,3 +1,5 @@
+package com.sdds.playground.sandbox
+
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.sdds.playground.sandbox.switch.SandboxSwitchPreviewOff
@@ -27,7 +29,7 @@ class ComposeSwitchScreenshotTest {
      */
     @Category(ScreenshotTests::class)
     @Test
-    internal fun testSwitchPreviewOn() {
+    fun testSwitchPreviewOn() {
         captureRoboImage {
             config.roborazziOptions
             SandboxSwitchPreviewOn()
@@ -36,7 +38,7 @@ class ComposeSwitchScreenshotTest {
 
     @Category(ScreenshotTests::class)
     @Test
-    internal fun testSwitchPreviewOff() {
+    fun testSwitchPreviewOff() {
         captureRoboImage {
             config.roborazziOptions
             SandboxSwitchPreviewOff()
@@ -45,7 +47,7 @@ class ComposeSwitchScreenshotTest {
 
     @Category(ScreenshotTests::class)
     @Test
-    internal fun testSwitchPreviewOnDisabled() {
+    fun testSwitchPreviewOnDisabled() {
         captureRoboImage {
             config.roborazziOptions
             SandboxSwitchPreviewOnDisabled()

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeTextFieldScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/ComposeTextFieldScreenshotTest.kt
@@ -1,0 +1,126 @@
+package com.sdds.playground.sandbox
+
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewHasDot
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewHasDotInsideEnd
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewInner
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewLInactive
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewLPlaceholder
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewLReadOnly
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewLSuccess
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewMWarning
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewSDefault
+import com.sdds.playground.sandbox.textfield.SandboxTextFieldPreviewXsError
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [SDK_NUMBER], qualifiers = RobolectricDeviceQualifiers.Pixel6)
+@RunWith(RobolectricTestRunner::class)
+class ComposeTextFieldScreenshotTest {
+
+    private val config = RoborazziConfig()
+
+    /**
+     * Для запуска только скриншот тестов
+     */
+    interface ScreenshotTests
+
+    /**
+     * Запуск скриншот тестов с использованием Preview
+     */
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewXsError() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewXsError()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewLSuccess() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewLSuccess()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewMWarning() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewMWarning()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewInner() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewInner()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewLInactive() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewLInactive()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewSDefault() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewSDefault()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewLReadOnly() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewLReadOnly()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewLPlaceholder() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewLPlaceholder()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewHasDot() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewHasDot()
+        }
+    }
+
+    @Category(ScreenshotTests::class)
+    @Test
+    fun testTextFieldPreviewHasDotInsideEnd() {
+        captureRoboImage {
+            config.roborazziOptions
+            SandboxTextFieldPreviewHasDotInsideEnd()
+        }
+    }
+}

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/Constant.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/Constant.kt
@@ -1,1 +1,3 @@
+package com.sdds.playground.sandbox
+
 internal const val SDK_NUMBER: Int = 33

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/RoborazziConfig.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/RoborazziConfig.kt
@@ -1,3 +1,5 @@
+package com.sdds.playground.sandbox
+
 import android.app.Application
 import android.content.pm.ActivityInfo
 import androidx.activity.ComponentActivity

--- a/playground/sandbox/build.gradle.kts
+++ b/playground/sandbox/build.gradle.kts
@@ -5,6 +5,8 @@ import com.sdds.plugin.themebuilder.ThemeBuilderMode
 plugins {
     id("convention.android-app")
     id(libs.plugins.themebuilder.get().pluginId)
+    alias(libs.plugins.roborazzi)
+    id("kotlin-parcelize")
 }
 
 android {
@@ -14,6 +16,9 @@ android {
     }
     buildFeatures {
         viewBinding = true
+    }
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
     }
 }
 
@@ -46,4 +51,10 @@ dependencies {
 
     // Unit tests
     testImplementation(libs.base.test.unit.jUnit)
+
+    //Screenshot tests
+    testImplementation(libs.test.roborazzi)
+    testImplementation(libs.test.roborazzi.compose)
+    testImplementation(libs.test.roborazzi.rule)
+    testImplementation(libs.base.test.unit.robolectric)
 }

--- a/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/SandboxActivity.kt
+++ b/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/SandboxActivity.kt
@@ -14,6 +14,7 @@ import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.navigation.NavigationView
+import com.sdds.playground.sandbox.core.view.ComponentFragment
 import com.sdds.playground.sandbox.databinding.MainActivityBinding
 
 /**
@@ -38,6 +39,12 @@ class SandboxActivity : AppCompatActivity() {
         appBarConfiguration = AppBarConfiguration(navigationSet, drawerLayout)
         setupActionBarWithNavController(navController, appBarConfiguration)
         navView.setupWithNavController(navController)
+
+        intent.extras?.let { extra ->
+            val destinationId = extra.getInt(DESTINATION_ID_ARG, R.id.nav_basic_button)
+            val bundle = extra.getBundle(ComponentFragment.DESTINATION_MESSAGE_ARG)
+            navController.navigate(destinationId, bundle)
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -52,8 +59,12 @@ class SandboxActivity : AppCompatActivity() {
         }
     }
 
-    private companion object {
-        val navigationSet = setOf(
+    companion object {
+        /**
+         * Идентификатор начального экрана
+         */
+        const val DESTINATION_ID_ARG = "DESTINATION_ID_ARG"
+        private val navigationSet = setOf(
             R.id.nav_basic_button,
             R.id.nav_icon_button,
             R.id.nav_checkbox,

--- a/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/buttons/BasicButtonFragment.kt
+++ b/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/buttons/BasicButtonFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.sdds.playground.sandbox.R
 import com.sdds.playground.sandbox.core.view.ComponentFragment
 import com.sdds.playground.sandbox.core.view.PropertiesOwner
 import com.sdds.uikit.Button
@@ -19,11 +20,12 @@ import kotlinx.coroutines.flow.onEach
 internal class BasicButtonFragment : ComponentFragment() {
 
     private val buttonViewModel by viewModels<ButtonParametersViewModel> {
-        ButtonParametersViewModelFactory(ButtonType.Basic)
+        ButtonParametersViewModelFactory(ButtonType.Basic, getDefaultState())
     }
 
     override val componentLayout: Button
         get() = Button(ContextThemeWrapper(requireContext(), currentVariant.styleRes))
+            .apply { id = R.id.basic_button }
             .also { button = it }
 
     override val propertiesOwner: PropertiesOwner

--- a/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/buttons/ButtonParametersViewModel.kt
+++ b/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/buttons/ButtonParametersViewModel.kt
@@ -22,10 +22,11 @@ import kotlinx.coroutines.flow.stateIn
  */
 internal class ButtonParametersViewModel(
     private val buttonType: ButtonType,
+    private val defaultState: ButtonUiState? = null,
 ) : ViewModel(), PropertiesOwner {
 
     private val _defaultState
-        get() = ButtonUiState(
+        get() = defaultState ?: ButtonUiState(
             when (buttonType) {
                 ButtonType.Basic -> BasicButtonVariant.BasicButtonLDefault
                 ButtonType.Icon -> IconButtonVariant.IconButtonLDefault
@@ -237,11 +238,12 @@ internal enum class ButtonType {
  */
 internal class ButtonParametersViewModelFactory(
     private val type: ButtonType,
+    private val defaultState: ButtonUiState? = null,
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         Log.e("ButtonParametersViewModelFactory", "create: type $type")
-        return ButtonParametersViewModel(buttonType = type) as T
+        return ButtonParametersViewModel(buttonType = type, defaultState = defaultState) as T
     }
 }

--- a/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/buttons/ButtonUiState.kt
+++ b/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/buttons/ButtonUiState.kt
@@ -1,8 +1,10 @@
 package com.sdds.playground.sandbox.buttons
 
+import android.os.Parcelable
 import androidx.annotation.StyleRes
 import com.sdds.playground.sandbox.R
 import com.sdds.uikit.Button
+import kotlinx.parcelize.Parcelize
 import com.sdds.icons.R.drawable as Icons
 
 /**
@@ -16,6 +18,7 @@ import com.sdds.icons.R.drawable as Icons
  * @property loading индикация загрузки
  * @property fixedSize режим фиксированного размера кнопки
  */
+@Parcelize
 internal data class ButtonUiState(
     val variant: ButtonVariant,
     val icon: ButtonIcon = ButtonIcon.No,
@@ -25,13 +28,14 @@ internal data class ButtonUiState(
     val enabled: Boolean = true,
     val loading: Boolean = false,
     val fixedSize: Boolean = false,
-)
+) : Parcelable
 
 /**
  * Стили вариаций кнопки
  * @property styleRes ресурс стиля
  */
-internal sealed interface ButtonVariant {
+@Parcelize
+internal sealed interface ButtonVariant : Parcelable {
 
     /**
      * Ресурс стиля
@@ -44,6 +48,7 @@ internal sealed interface ButtonVariant {
  * Стили вариаций BasicButton
  * @property styleRes ресурс стиля
  */
+@Parcelize
 internal enum class BasicButtonVariant(@StyleRes override val styleRes: Int) : ButtonVariant {
     BasicButtonLDefault(R.style.Theme_Sandbox_ComponentOverlays_BasicButtonLDefault),
     BasicButtonLSecondary(R.style.Theme_Sandbox_ComponentOverlays_BasicButtonLSecondary),
@@ -94,6 +99,7 @@ internal enum class BasicButtonVariant(@StyleRes override val styleRes: Int) : B
  * Стили вариаций IconButton
  * @property styleRes ресурс стиля
  */
+@Parcelize
 internal enum class IconButtonVariant(@StyleRes override val styleRes: Int) : ButtonVariant {
     IconButtonLDefault(R.style.Theme_Sandbox_ComponentOverlays_IconButtonLDefault),
     IconButtonLSecondary(R.style.Theme_Sandbox_ComponentOverlays_IconButtonLSecondary),
@@ -187,7 +193,8 @@ internal enum class IconButtonVariant(@StyleRes override val styleRes: Int) : Bu
 /**
  * Иконка кнопки
  */
-internal sealed class ButtonIcon(val iconId: Int = Icons.ic_plasma_24) {
+@Parcelize
+internal sealed class ButtonIcon(val iconId: Int = Icons.ic_plasma_24) : Parcelable {
 
     /**
      * Иконка вначале кнопки

--- a/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/core/view/ComponentFragment.kt
+++ b/playground/sandbox/src/main/kotlin/com/sdds/playground/sandbox/core/view/ComponentFragment.kt
@@ -1,5 +1,6 @@
 package com.sdds.playground.sandbox.core.view
 
+import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -32,6 +33,14 @@ internal abstract class ComponentFragment : Fragment(), PropertiesAdapter.Intera
     abstract val componentLayout: View
 
     abstract val propertiesOwner: PropertiesOwner
+
+    protected inline fun <reified T> getDefaultState(): T? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable(DESTINATION_MESSAGE_ARG, T::class.java)
+        } else {
+            return arguments?.getParcelable(DESTINATION_MESSAGE_ARG)
+        }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         _binding = FragmentComponentScaffoldBinding.inflate(inflater, container, false)
@@ -70,6 +79,7 @@ internal abstract class ComponentFragment : Fragment(), PropertiesAdapter.Intera
             addView(componentLayout, layoutParams)
         }
     }
+
     override fun onDestroyView() {
         super.onDestroyView()
         propertiesAdapter.setInteractionListener(null)
@@ -87,6 +97,7 @@ internal abstract class ComponentFragment : Fragment(), PropertiesAdapter.Intera
                 currentValue = property.value,
                 choices = property.variants,
             ).show(childFragmentManager, "SingleChoicePropertyEditor")
+
             is Property.IntProperty -> EditorFragment.textEditor(
                 propertyName = property.name,
                 currentValue = property.value.toString(),
@@ -97,5 +108,9 @@ internal abstract class ComponentFragment : Fragment(), PropertiesAdapter.Intera
                 currentValue = property.value,
             ).show(childFragmentManager, "StringPropertyEditor")
         }
+    }
+
+    companion object {
+        const val DESTINATION_MESSAGE_ARG = "DestinationMessage"
     }
 }

--- a/playground/sandbox/src/main/res/values/components_ids.xml
+++ b/playground/sandbox/src/main/res/values/components_ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="id" name="basic_button"/>
+</resources>

--- a/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/Constant.kt
+++ b/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/Constant.kt
@@ -1,0 +1,3 @@
+package com.sdds.playground.sandbox
+
+internal const val SDK_NUMBER: Int = 33

--- a/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/RoborazziConfig.kt
+++ b/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/RoborazziConfig.kt
@@ -1,0 +1,22 @@
+package com.sdds.playground.sandbox
+
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziOptions
+
+class RoborazziConfig {
+
+    /**
+     * Объект RoborazziOptions для захвата и сравнения изображений
+     * recordOptions задает параметры для захвата
+     * compareOptions задает погрешность сравнения
+     **/
+    @OptIn(ExperimentalRoborazziApi::class)
+    val roborazziOptions = RoborazziOptions(
+        recordOptions = RoborazziOptions.RecordOptions(
+            resizeScale = 0.5,
+        ),
+        compareOptions = RoborazziOptions.CompareOptions(
+            changeThreshold = 0.01f,
+        ),
+    )
+}

--- a/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/TestUtils.kt
+++ b/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/TestUtils.kt
@@ -1,0 +1,19 @@
+package com.sdds.playground.sandbox
+
+import android.content.Intent
+import android.os.Parcelable
+import androidx.core.os.bundleOf
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.sdds.playground.sandbox.core.view.ComponentFragment.Companion.DESTINATION_MESSAGE_ARG
+
+fun launchScreen(
+    destinationId: Int,
+    state: Parcelable,
+
+) {
+    val intent = Intent(ApplicationProvider.getApplicationContext(), SandboxActivity::class.java)
+    intent.putExtra(SandboxActivity.DESTINATION_ID_ARG, destinationId)
+    intent.putExtra(DESTINATION_MESSAGE_ARG, bundleOf(DESTINATION_MESSAGE_ARG to state))
+    ActivityScenario.launch<SandboxActivity>(intent)
+}

--- a/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/ViewSystemButtonScreenshotTest.kt
+++ b/playground/sandbox/src/test/kotlin/com/sdds/playground/sandbox/ViewSystemButtonScreenshotTest.kt
@@ -1,0 +1,205 @@
+package com.sdds.playground.sandbox
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.sdds.playground.sandbox.buttons.BasicButtonVariant
+import com.sdds.playground.sandbox.buttons.ButtonIcon
+import com.sdds.playground.sandbox.buttons.ButtonUiState
+import com.sdds.playground.sandbox.buttons.ButtonVariant
+import com.sdds.playground.sandbox.buttons.IconButtonVariant
+import com.sdds.uikit.Button
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [SDK_NUMBER], qualifiers = RobolectricDeviceQualifiers.Pixel6)
+class ViewSystemButtonScreenshotTest {
+
+    private val config = RoborazziConfig()
+
+    @Test
+    fun testButtonSizeLDefault() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonLDefault,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeXSDefault() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonXSDefault,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeMSecondary() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonMSecondary,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeSClear() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonSClear,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeLPositive() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonLPositive,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeMNegative() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonMNegative,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "Value",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeSWarning() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonSWarning,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeXSBlack() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonXSBlack,
+                icon = ButtonIcon.Start,
+                buttonLabel = "Label",
+                buttonValue = "Value",
+                spacing = Button.Spacing.SpaceBetween,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+
+    @Test
+    fun testButtonSizeLWhite() {
+        config.roborazziOptions
+        launchScreen(
+            R.id.nav_basic_button,
+            ButtonUiState(
+                variant = BasicButtonVariant.BasicButtonLWhite,
+                icon = ButtonIcon.End,
+                buttonLabel = "Label",
+                buttonValue = "",
+                spacing = Button.Spacing.Packed,
+                enabled = true,
+                loading = false,
+                fixedSize = false,
+            ),
+        )
+        onView(withId(R.id.basic_button))
+            .captureRoboImage()
+    }
+}


### PR DESCRIPTION
- Added screenshots for View System Button Component
- Added package directory for sandbox and sandbox-compose screenshot tests
- Added one preview in Button Compose
- Added TestUtils for Intent SandboxActivity
- Added TextField previews and screenshot tests
- Added Chip previews and screenshot tests

![image](https://github.com/user-attachments/assets/44c58dfd-9102-4aa8-8549-39fb42eb9aec)

![image](https://github.com/user-attachments/assets/70071ca2-3570-4b90-8a1c-af31e0836eb5)

![image](https://github.com/user-attachments/assets/695e32bd-aca5-4151-9a52-f85e482bd753)

![image](https://github.com/user-attachments/assets/5553a804-8a32-48d4-aaf6-69a117de2623)
