### PR TITLE
fix(sdds-acore/uikit-compose): button text was fixed

### DIFF
--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/BaseButton.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/BaseButton.kt
@@ -140,10 +140,7 @@ internal fun RowScope.ButtonText(
                 Button.Spacing.Packed -> Arrangement.Center
                 Button.Spacing.SpaceBetween -> Arrangement.SpaceBetween
             },
-            modifier = when (spacing) {
-                Button.Spacing.Packed -> modifier
-                Button.Spacing.SpaceBetween -> modifier.weight(1f)
-            },
+            modifier = modifier.weight(1f, spacing == Button.Spacing.SpaceBetween),
         ) {
             Text(
                 text = label,
@@ -164,7 +161,7 @@ internal fun RowScope.ButtonText(
     } else {
         Text(
             text = label,
-            modifier = modifier,
+            modifier = modifier.weight(1f, false),
             style = labelTextStyle,
             softWrap = false,
             overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
* Исправил проблему, когда текст при переполнении заезжал на иконку справа в режиме spacing == Packed


https://github.com/user-attachments/assets/d34c2387-86e4-4f17-b9d2-c750d89ba545

