### PR TITLE
feat(sdds-acore/uikit-compose): setup local text style

### DIFF
--- a/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/textfield/TextFieldScreen.kt
+++ b/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/textfield/TextFieldScreen.kt
@@ -23,7 +23,6 @@ import com.sdds.playground.sandbox.buttons.SandboxButton
 import com.sdds.playground.sandbox.chip.SandboxEmbeddedChip
 import com.sdds.playground.sandbox.core.ComponentScaffold
 import com.sdds.playground.sandbox.progress.SandboxProgress
-import com.sdds.playground.sandbox.tokens.compose.SddsServTheme
 
 /**
  * Экран с компонентом [SandboxProgress]
@@ -121,7 +120,6 @@ private fun ChipsContent(
                 Icon(
                     painter = painterResource(id = com.sdds.icons.R.drawable.ic_close_24),
                     contentDescription = "",
-                    tint = SddsServTheme.colors.textDefaultSecondary,
                     modifier = Modifier.clickable(onClick = { onChipClosePressed?.invoke(chip) }),
                 )
             },
@@ -140,7 +138,6 @@ private fun Boolean.getExampleIcon(icon: Icon): (@Composable () -> Unit)? {
             Icon(
                 painter = painterResource(id = icon.res),
                 contentDescription = "",
-                tint = SddsServTheme.colors.textDefaultSecondary,
             )
         }
     } else {

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeThemeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeThemeGenerator.kt
@@ -56,6 +56,10 @@ internal class ComposeThemeGenerator(
                     "remember",
                 ),
             )
+            addImport(
+                packageName = "com.sdds.compose.uikit",
+                names = listOf("ProvideTextStyle"),
+            )
         }
     }
 

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeTypographyAttributeGenerator.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/generator/theme/compose/ComposeTypographyAttributeGenerator.kt
@@ -59,8 +59,6 @@ internal class ComposeTypographyAttributeGenerator(
         addLocalTypographyVal()
         addDynamicTypographyFun()
         addBreakPointFun()
-        addLocalTextStyleVal()
-        addProvideTextStyleComposable()
 
         typographyKtFileBuilder.build(outputLocation)
     }
@@ -86,7 +84,6 @@ internal class ComposeTypographyAttributeGenerator(
                 names = listOf(
                     "staticCompositionLocalOf",
                     "Immutable",
-                    "CompositionLocalProvider",
                     "structuralEqualityPolicy",
                     "compositionLocalOf",
                 ),
@@ -223,42 +220,6 @@ internal class ComposeTypographyAttributeGenerator(
                 ?: safeTokenData.small[attributeName]
                 ?: safeTokenData.large[attributeName]
         }
-    }
-
-    private fun addLocalTextStyleVal() {
-        typographyKtFileBuilder.appendRootVal(
-            name = "Local${camelThemeName}TextStyle",
-            typeName = KtFileBuilder.TypeProvidableCompositionLocal,
-            parameterizedType = KtFileBuilder.TypeTextStyle,
-            initializer = "compositionLocalOf(structuralEqualityPolicy()) { TextStyle.Default }",
-            modifiers = listOf(Modifier.PRIVATE),
-        )
-    }
-
-    private fun addProvideTextStyleComposable() {
-        typographyKtFileBuilder.appendRootFun(
-            name = "ProvideTextStyle",
-            params = listOf(
-                KtFileBuilder.FunParameter(
-                    name = "value",
-                    type = KtFileBuilder.TypeTextStyle,
-                ),
-                KtFileBuilder.FunParameter(
-                    name = "content",
-                    type = KtFileBuilder.getLambdaType(
-                        annotation = KtFileBuilder.TypeAnnotationComposable,
-                    ),
-                ),
-            ),
-            modifiers = listOf(Modifier.INTERNAL),
-            annotation = KtFileBuilder.TypeAnnotationComposable,
-            body = listOf(
-                "val mergedStyle = Local${camelThemeName}TextStyle.current.merge(value)\n",
-                "CompositionLocalProvider(" +
-                    "Local${camelThemeName}TextStyle provides mergedStyle, " +
-                    "content = content)",
-            ),
-        )
     }
 
     private companion object {

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/token/GradientTokens.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/token/GradientTokens.kt
@@ -83,8 +83,6 @@ internal data class BackgroundGradientTokenValue(
  * Значение токена sweep градиента
  * @property colors цвета градиента
  * @property locations позиции цвета градиента
- * @property startAngle угол начала градиента в градусах
- * @property endAngle угол окончания градиента в градусах
  * @property centerX координата X центра [0, 1]
  * @property centerY координата Y центра [0, 1]
  */

--- a/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_1.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_1.txt
@@ -79,7 +79,6 @@ private val Dp.px: Int
 package com.sdds.playground.themebuilder.tokens
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
@@ -89,7 +88,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sdds.playground.themebuilder.tokens.ThemeTypography
-import kotlin.Unit
 
 /**
  * Типографика Theme
@@ -102,9 +100,6 @@ public data class ThemeTypography internal constructor(
 
 internal val LocalThemeTypography: ProvidableCompositionLocal<ThemeTypography> =
         staticCompositionLocalOf { mediumThemeTypography() }
-
-private val LocalThemeTextStyle: ProvidableCompositionLocal<TextStyle> =
-        compositionLocalOf(structuralEqualityPolicy()) { TextStyle.Default }
 
 /**
  * Возвращает [ThemeTypography] для WindowSizeClass.Compact
@@ -143,10 +138,4 @@ public fun WindowSizeClass.widthBreakPoint(): Dp = when (this) {
     WindowSizeClass.Expanded -> 840.0.dp
     WindowSizeClass.Medium -> 600.0.dp
     WindowSizeClass.Compact -> 0.dp
-}
-
-@Composable
-internal fun ProvideTextStyle(`value`: TextStyle, content: @Composable () -> Unit): Unit {
-    val mergedStyle = LocalThemeTextStyle.current.merge(value)
-    CompositionLocalProvider(LocalThemeTextStyle provides mergedStyle, content = content)
 }

--- a/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_2.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_2.txt
@@ -79,7 +79,6 @@ private val Dp.px: Int
 package com.sdds.playground.themebuilder.tokens
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
@@ -89,7 +88,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sdds.playground.themebuilder.tokens.ThemeTypography
-import kotlin.Unit
 
 /**
  * Типографика Theme
@@ -102,9 +100,6 @@ public data class ThemeTypography internal constructor(
 
 internal val LocalThemeTypography: ProvidableCompositionLocal<ThemeTypography> =
         staticCompositionLocalOf { mediumThemeTypography() }
-
-private val LocalThemeTextStyle: ProvidableCompositionLocal<TextStyle> =
-        compositionLocalOf(structuralEqualityPolicy()) { TextStyle.Default }
 
 /**
  * Возвращает [ThemeTypography] для WindowSizeClass.Compact
@@ -143,10 +138,4 @@ public fun WindowSizeClass.widthBreakPoint(): Dp = when (this) {
     WindowSizeClass.Expanded -> 840.0.dp
     WindowSizeClass.Medium -> 600.0.dp
     WindowSizeClass.Compact -> 0.dp
-}
-
-@Composable
-internal fun ProvideTextStyle(`value`: TextStyle, content: @Composable () -> Unit): Unit {
-    val mergedStyle = LocalThemeTextStyle.current.merge(value)
-    CompositionLocalProvider(LocalThemeTextStyle provides mergedStyle, content = content)
 }

--- a/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_3.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/attrs-outputs/TypographyOutputKt_3.txt
@@ -79,7 +79,6 @@ private val Dp.px: Int
 package com.sdds.playground.themebuilder.tokens
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
@@ -89,7 +88,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sdds.playground.themebuilder.tokens.ThemeTypography
-import kotlin.Unit
 
 /**
  * Типографика Theme
@@ -102,9 +100,6 @@ public data class ThemeTypography internal constructor(
 
 internal val LocalThemeTypography: ProvidableCompositionLocal<ThemeTypography> =
         staticCompositionLocalOf { mediumThemeTypography() }
-
-private val LocalThemeTextStyle: ProvidableCompositionLocal<TextStyle> =
-        compositionLocalOf(structuralEqualityPolicy()) { TextStyle.Default }
 
 /**
  * Возвращает [ThemeTypography] для WindowSizeClass.Compact
@@ -143,10 +138,4 @@ public fun WindowSizeClass.widthBreakPoint(): Dp = when (this) {
     WindowSizeClass.Expanded -> 840.0.dp
     WindowSizeClass.Medium -> 600.0.dp
     WindowSizeClass.Compact -> 0.dp
-}
-
-@Composable
-internal fun ProvideTextStyle(`value`: TextStyle, content: @Composable () -> Unit): Unit {
-    val mergedStyle = LocalThemeTextStyle.current.merge(value)
-    CompositionLocalProvider(LocalThemeTextStyle provides mergedStyle, content = content)
 }

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/ThemeOutputKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/ThemeOutputKt.txt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
+import com.sdds.compose.uikit.ProvideTextStyle
 import com.sdds.playground.themebuilder.tokens.compose.TestColors
 import com.sdds.playground.themebuilder.tokens.compose.TestGradients
 import com.sdds.playground.themebuilder.tokens.compose.TestShapes

--- a/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/ThemeOutputKtWithTextSelectionAndTextStyle.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/theme-outputs/ThemeOutputKtWithTextSelectionAndTextStyle.txt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
+import com.sdds.compose.uikit.ProvideTextStyle
 import com.sdds.playground.themebuilder.tokens.compose.TestColors
 import com.sdds.playground.themebuilder.tokens.compose.TestGradients
 import com.sdds.playground.themebuilder.tokens.compose.TestShapes


### PR DESCRIPTION
* Убрал ручную установку цвета иконкам в text field в песочнице, чтобы работал LocalTint
* Убрал генерацию проперти LocalTextStyle и функции ProvideTextStyle(). В теме теперь делается вызов одноименной функции из uikit и теперь этот механизм работает и все компоненты Text обеспечены дефолтным стилем из темы.
<img width="222" alt="Снимок экрана 2024-09-27 в 15 39 21" src="https://github.com/user-attachments/assets/c8b1d3f8-290c-4131-98ff-dcca694437e5">

