### PR TITLE
chore: Versions bump

### DIFF
--- a/sdds-core/plugin_theme_builder/gradle.properties
+++ b/sdds-core/plugin_theme_builder/gradle.properties
@@ -1,3 +1,3 @@
 versionMajor=0
-versionMinor=4
+versionMinor=5
 versionPatch=0

--- a/sdds-core/uikit-compose/gradle.properties
+++ b/sdds-core/uikit-compose/gradle.properties
@@ -2,5 +2,5 @@ nexus.artifactId=sdds-uikit-compose
 nexus.snapshot=false
 nexus.description=SDDS UIKit library with base components for android jetpack compose
 versionMajor=0
-versionMinor=5
+versionMinor=6
 versionPatch=0

--- a/sdds-core/uikit/gradle.properties
+++ b/sdds-core/uikit/gradle.properties
@@ -2,5 +2,5 @@ nexus.artifactId=sdds-uikit
 nexus.snapshot=false
 nexus.description=SDDS UIKit library with base components for android view system
 versionMajor=0
-versionMinor=3
+versionMinor=4
 versionPatch=0


### PR DESCRIPTION
sdds-core uikit, uikit compose and plugin_theme-builder versions were bumped.