### PR TITLE
build: Artifact distribution workflows.

### DIFF
--- a/.github/scripts/testfairy-uploader.sh
+++ b/.github/scripts/testfairy-uploader.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+# This upload script is both for iOS and Android.
+echo "Run"
+
+UPLOADER_VERSION=2.14
+
+# Should email testers about new version. Set to "off" to disable email notifications.
+NOTIFY="on"
+
+# If AUTO_UPDATE is "on" users of older versions will be prompt to update to this build next time they run the app
+AUTO_UPDATE="off"
+
+# Use comment field to add release notes. Text will be included in the email sent to testers and in landing pages.
+COMMENT=""
+
+# locations of various tools
+CURL=curl
+
+SERVER_ENDPOINT=https://upload.testfairy.com
+
+usage() {
+	echo "Usage: testfairy-upload-ios.sh APP_FILENAME"
+	echo
+}
+	
+verify_tools() {
+
+	# Windows users: this script requires curl. If not installed please get from http://cygwin.com/
+
+	# Check 'curl' tool
+	"${CURL}" --help >/dev/null
+	if [ $? -ne 0 ]; then
+		echo "Could not run curl tool, please check settings"
+		exit 1
+	fi
+}
+
+verify_settings() {
+	if [ -z "${TESTFAIRY_API_KEY}" ]; then
+		usage
+		echo "Please update API_KEY with your private API key, as noted in the Settings page"
+		exit 1
+	fi
+}
+
+if [ $# -ne 1 ]; then
+	usage
+	exit 1
+fi
+
+# before even going on, make sure all tools work
+verify_tools
+verify_settings
+
+APP_FILENAME=$1
+if [ ! -f "${APP_FILENAME}" ]; then
+	usage
+	echo "Can't find file: ${APP_FILENAME}"
+	exit 2
+fi
+echo "${APP_FILENAME}"
+# temporary file paths
+DATE=`date`
+
+/bin/echo -n "Uploading ${APP_FILENAME} to TestFairy.. "
+JSON=$( "${CURL}" -s ${SERVER_ENDPOINT}/api/upload -F api_key=${TESTFAIRY_API_KEY} -F file="@${APP_FILENAME}" -F comment="${COMMENT}" -F groups="plasma-team" -F auto-update="${AUTO_UPDATE}" -F notify="${NOTIFY}" -A "TestFairy Command Line Uploader ${UPLOADER_VERSION}" )
+
+URL=$( echo ${JSON} | sed 's/\\\//\//g' | sed -n 's/.*"build_url"\s*:\s*"\([^"]*\)".*/\1/p' )
+if [ -z "$URL" ]; then
+	echo "FAILED!"
+	echo
+	echo "Build uploaded, but no reply from server. Please contact support@testfairy.com"
+	exit 1
+fi
+
+echo "OK!"
+echo
+echo "Build was successfully uploaded to TestFairy and is available at:"
+echo ${URL}

--- a/.github/workflows/publish-icons-release.yml
+++ b/.github/workflows/publish-icons-release.yml
@@ -34,3 +34,13 @@ jobs:
         with:
           name: distribution
           path: sdds-core/icons/build/distributions/*.zip
+
+      - name: Create or Update Release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          draft: true
+          allowUpdates: true
+          omitBody: true
+          artifacts: sdds-core/icons/build/distributions/*.zip

--- a/.github/workflows/publish-sandbox-compose.yml
+++ b/.github/workflows/publish-sandbox-compose.yml
@@ -54,4 +54,9 @@ jobs:
           omitBody: true
           artifacts: playground/sandbox-compose/build/outputs/apk/release/*.apk
 
+      - name: Distribute to testers
+        env:
+          TESTFAIRY_API_KEY: ${{ secrets.TESTFAIRY_API_KEY }}
+        run: sh .github/scripts/testfairy-uploader.sh playground/sandbox-compose/build/outputs/apk/release/*.apk
+
 

--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -54,4 +54,8 @@ jobs:
           allowUpdates: true
           artifacts: playground/sandbox/build/outputs/apk/release/*.apk
 
+      - name: Distribute to testers
+        env:
+          TESTFAIRY_API_KEY: ${{ secrets.TESTFAIRY_API_KEY }}
+        run: sh .github/scripts/testfairy-uploader.sh playground/sandbox/build/outputs/apk/release/*.apk
 

--- a/.github/workflows/publish-uikit-compose-release.yml
+++ b/.github/workflows/publish-uikit-compose-release.yml
@@ -34,3 +34,13 @@ jobs:
         with:
           name: distribution
           path: sdds-core/uikit-compose/build/distributions/*.zip
+
+      - name: Create or Update Release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          draft: true
+          allowUpdates: true
+          omitBody: true
+          artifacts: sdds-core/uikit-compose/build/distributions/*.zip

--- a/.github/workflows/publish-uikit-release.yml
+++ b/.github/workflows/publish-uikit-release.yml
@@ -34,3 +34,13 @@ jobs:
         with:
           name: distribution
           path: sdds-core/uikit/build/distributions/*.zip
+
+      - name: Create or Update Release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          draft: true
+          allowUpdates: true
+          omitBody: true
+          artifacts: sdds-core/uikit/build/distributions/*.zip

--- a/build-system/conventions/src/main/kotlin/convention.maven-publish.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.maven-publish.gradle.kts
@@ -91,6 +91,7 @@ signing {
 // plugins with single-digital GitHub stars. So for now, we create a zip file and use the manual
 // upload process.
 // See https://github.com/gradle/gradle/issues/28120
+val distributionName = "$nexusArtifactId-v${versionInfo.fullName}"
 tasks.register<Zip>("generateDistributionZip") {
     val publishTask = tasks.named(
         "publishReleasePublicationToLocalRepository",
@@ -98,13 +99,13 @@ tasks.register<Zip>("generateDistributionZip") {
     from(publishTask.map { it.repository.url })
     into("")
     exclude("**/maven-metadata*.*") // Sonatype does not want these files in ZIP file
-    archiveFileName.set("$nexusArtifactId.zip")
+    archiveFileName.set("$distributionName.zip")
 }
 
 tasks.register<MavenPublishTask>("mavenPublish") {
     token.set(properties["publicationToken"]?.toString() ?: System.getenv("PP_AUTH_TOKEN"))
-    publicationType.set(properties["publicationType"]?.toString() ?: "USER_MANAGED")
-    publicationName.set("$nexusArtifactId-${versionInfo.fullName}")
-    artifact.set(File("${project.buildDir}/distributions/${nexusArtifactId}.zip"))
+    publicationType.set(properties["publicationType"]?.toString() ?: "AUTOMATIC")
+    publicationName.set(distributionName)
+    artifact.set(File("${project.buildDir}/distributions/$distributionName.zip"))
     dependsOn(tasks.first { it.name == "generateDistributionZip" })
 }


### PR DESCRIPTION
- Sandbox applications releases now can be distributed to testes via TestFairy. 
- Library publishing workflows were improved: release artifacts are now automatically attached to GitHub Releases and automatically published at MavenCentral.