### PR TITLE
fix(sdds-alibs/plasmab2c): disable spotlessApplyAll for tokens libs

### DIFF
--- a/tokens/build.gradle.kts
+++ b/tokens/build.gradle.kts
@@ -232,6 +232,7 @@ tasks.replace("testAll")
 tasks.replace("testDebugAll")
 tasks.replace("detektAll")
 tasks.replace("spotlessCheckAll")
+tasks.replace("spotlessApplyAll")
 tasks.replace("apiCheckAll")
 
 tasks.register("cleanAll") {


### PR DESCRIPTION
отключил spotlessApplyAll для библиотек из модуля tokens