### PR TITLE
fix(sdds-acore/uikit-compose): fix text field height

### DIFF
--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/BaseTextField.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/BaseTextField.kt
@@ -186,6 +186,7 @@ internal fun BaseTextField(
             onValueChange = onValueChange,
             modifier = Modifier
                 .defaultMinSize(minHeight = dimensions.boxMinHeight)
+                .weight(1f, fill = false)
                 .fillMaxWidth()
                 .applyFieldIndicator(
                     fieldType,


### PR DESCRIPTION
* Исправил некорректное поведение text field при достижении ограничения


https://github.com/user-attachments/assets/f2f42f48-a3c0-4c16-a9a7-6efb7c0939f4

