### PR TITLE
feat(sdds-acore/theme-builder): generate color variations for compose button

### DIFF
--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/builder/KtFileBuilder.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/builder/KtFileBuilder.kt
@@ -3,6 +3,7 @@ package com.sdds.plugin.themebuilder.internal.builder
 import com.sdds.plugin.themebuilder.internal.utils.unsafeLazy
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
@@ -412,6 +413,13 @@ internal class KtFileBuilder(
                 }
                 body?.let { builder.addCode(it) }
             }
+            is Getter.AnnotatedCodeBlock -> {
+                modifiers?.let { builder.addModifiers(it.toKModifiers()) }
+                annotations?.let { annotationList ->
+                    annotationList.forEach { builder.addAnnotation(it) }
+                }
+                body?.let { builder.addCode(it) }
+            }
         }
         return builder.build()
     }
@@ -489,6 +497,15 @@ internal class KtFileBuilder(
             val annotations: List<ClassName>? = null,
             val modifiers: List<Modifier>? = null,
             val body: String? = null,
+        ) : Getter()
+
+        /**
+         * Геттер
+         */
+        data class AnnotatedCodeBlock(
+            val annotations: List<ClassName>? = null,
+            val modifiers: List<Modifier>? = null,
+            val body: CodeBlock? = null,
         ) : Getter()
     }
 

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/BasicButtonStyleGeneratorCompose.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/BasicButtonStyleGeneratorCompose.kt
@@ -5,6 +5,8 @@ import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.utils.ResourceReferenceProvider
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.withIndent
 import java.util.Locale
 
 internal class BasicButtonStyleGeneratorCompose(
@@ -34,6 +36,7 @@ internal class BasicButtonStyleGeneratorCompose(
     override fun addCode(config: ButtonComponentConfig, ktFileBuilder: KtFileBuilder) {
         super.addCode(config, ktFileBuilder)
         ktFileBuilder.addSizes(config)
+        ktFileBuilder.addColors(config)
     }
 
     private fun KtFileBuilder.addSizes(config: ButtonComponentConfig) {
@@ -70,6 +73,35 @@ internal class BasicButtonStyleGeneratorCompose(
                                 .labelStyle($themeClassName.typography.${sizeData.labelStyle?.toKtTokenName()})
                                 .valueStyle($themeClassName.typography.${sizeData.valueStyle?.toKtTokenName()})
                     """.trimIndent(),
+                ),
+            )
+        }
+    }
+
+    private fun KtFileBuilder.addColors(config: ButtonComponentConfig) {
+        val colorVariations = config.variations.color
+        val builderType = getInternalClassType(
+            "BasicButtonStyleBuilder",
+            "com.sdds.compose.uikit",
+        )
+        CodeBlock.builder().add("").build()
+        colorVariations.forEach { (color, colorData) ->
+            appendRootVal(
+                name = color.capitalize(Locale.getDefault()),
+                typeName = builderType,
+                receiver = builderType,
+                getter = KtFileBuilder.Getter.AnnotatedCodeBlock(
+                    annotations = listOf(KtFileBuilder.TypeAnnotationComposable),
+                    body = CodeBlock.builder()
+                        .add("return this.colors {\n")
+                        .withIndent {
+                            add(colorData.getContentColor())
+                            add(colorData.getBackgroundColor(config.invariant))
+                            add(colorData.getValueColor())
+                            add(colorData.getSpinnerMode(config.invariant))
+                        }
+                        .add("}\n")
+                        .build(),
                 ),
             )
         }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/BasicButtonStyleGeneratorCompose.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/BasicButtonStyleGeneratorCompose.kt
@@ -84,7 +84,6 @@ internal class BasicButtonStyleGeneratorCompose(
             "BasicButtonStyleBuilder",
             "com.sdds.compose.uikit",
         )
-        CodeBlock.builder().add("").build()
         colorVariations.forEach { (color, colorData) ->
             appendRootVal(
                 name = color.capitalize(Locale.getDefault()),

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/IconButtonStyleGeneratorCompose.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/IconButtonStyleGeneratorCompose.kt
@@ -5,6 +5,8 @@ import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.utils.ResourceReferenceProvider
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.withIndent
 import java.util.Locale
 
 internal class IconButtonStyleGeneratorCompose(
@@ -34,6 +36,7 @@ internal class IconButtonStyleGeneratorCompose(
     override fun addCode(config: ButtonComponentConfig, ktFileBuilder: KtFileBuilder) {
         super.addCode(config, ktFileBuilder)
         ktFileBuilder.addSizes(config)
+        ktFileBuilder.addColors(config)
     }
 
     private fun KtFileBuilder.addSizes(config: ButtonComponentConfig) {
@@ -66,6 +69,33 @@ internal class IconButtonStyleGeneratorCompose(
                                     ),
                                 )
                     """.trimIndent(),
+                ),
+            )
+        }
+    }
+
+    private fun KtFileBuilder.addColors(config: ButtonComponentConfig) {
+        val colorVariations = config.variations.color
+        val builderType = getInternalClassType(
+            "IconButtonStyleBuilder",
+            "com.sdds.compose.uikit",
+        )
+        colorVariations.forEach { (color, colorData) ->
+            appendRootVal(
+                name = color.capitalize(Locale.getDefault()),
+                typeName = builderType,
+                receiver = builderType,
+                getter = KtFileBuilder.Getter.AnnotatedCodeBlock(
+                    annotations = listOf(KtFileBuilder.TypeAnnotationComposable),
+                    body = CodeBlock.builder()
+                        .add("return this.colors {\n")
+                        .withIndent {
+                            add(colorData.getContentColor())
+                            add(colorData.getBackgroundColor(config.invariant))
+                            add(colorData.getSpinnerMode(config.invariant))
+                        }
+                        .add("}\n")
+                        .build(),
                 ),
             )
         }

--- a/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/LinkButtonStyleGeneratorCompose.kt
+++ b/sdds-core/plugin_theme_builder/src/main/kotlin/com/sdds/plugin/themebuilder/internal/components/button/LinkButtonStyleGeneratorCompose.kt
@@ -5,6 +5,8 @@ import com.sdds.plugin.themebuilder.internal.builder.KtFileBuilder
 import com.sdds.plugin.themebuilder.internal.dimens.DimensAggregator
 import com.sdds.plugin.themebuilder.internal.factory.KtFileBuilderFactory
 import com.sdds.plugin.themebuilder.internal.utils.ResourceReferenceProvider
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.withIndent
 import java.util.Locale
 
 internal class LinkButtonStyleGeneratorCompose(
@@ -34,6 +36,7 @@ internal class LinkButtonStyleGeneratorCompose(
     override fun addCode(config: ButtonComponentConfig, ktFileBuilder: KtFileBuilder) {
         super.addCode(config, ktFileBuilder)
         ktFileBuilder.addSizes(config)
+        ktFileBuilder.addColors(config)
     }
 
     private fun KtFileBuilder.addSizes(config: ButtonComponentConfig) {
@@ -65,6 +68,33 @@ internal class LinkButtonStyleGeneratorCompose(
                                 )
                                 .labelStyle($themeClassName.typography.${sizeData.labelStyle?.toKtTokenName()})
                     """.trimIndent(),
+                ),
+            )
+        }
+    }
+
+    private fun KtFileBuilder.addColors(config: ButtonComponentConfig) {
+        val colorVariations = config.variations.color
+        val builderType = getInternalClassType(
+            "LinkButtonStyleBuilder",
+            "com.sdds.compose.uikit",
+        )
+        colorVariations.forEach { (color, colorData) ->
+            appendRootVal(
+                name = color.capitalize(Locale.getDefault()),
+                typeName = builderType,
+                receiver = builderType,
+                getter = KtFileBuilder.Getter.AnnotatedCodeBlock(
+                    annotations = listOf(KtFileBuilder.TypeAnnotationComposable),
+                    body = CodeBlock.builder()
+                        .add("return this.colors {\n")
+                        .withIndent {
+                            add(colorData.getContentColor())
+                            add(colorData.getBackgroundColor(config.invariant))
+                            add(colorData.getSpinnerMode(config.invariant))
+                        }
+                        .add("}\n")
+                        .build(),
                 ),
             )
         }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/components/button/BasicButtonStyleGeneratorComposeTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/components/button/BasicButtonStyleGeneratorComposeTest.kt
@@ -126,7 +126,51 @@ class BasicButtonStyleGeneratorComposeTest {
                         valueMargin = 4f,
                     ),
                 ),
-                color = emptyMap(),
+                color = mapOf(
+                    "default" to ButtonComponentConfig.ColorScheme(
+                        contentColor = ButtonComponentConfig.Color(
+                            default = "textInversePrimaryActive",
+                            states = listOf(
+                                ButtonComponentConfig.ColorState(
+                                    listOf("pressed"),
+                                    "surfaceInversePrimaryPressed",
+                                ),
+                            ),
+                        ),
+                        backgroundColor = ButtonComponentConfig.Color(
+                            default = "surfaceInversePrimaryActive",
+                            states = listOf(
+                                ButtonComponentConfig.ColorState(
+                                    listOf("pressed", "focused"),
+                                    "surfaceInversePrimaryPressed",
+                                ),
+                            ),
+                        ),
+                        valueColor = ButtonComponentConfig.Color(
+                            default = "textInversePrimaryActive",
+                            states = emptyList(),
+                        ),
+                    ),
+                    "warning" to ButtonComponentConfig.ColorScheme(
+                        contentColor = ButtonComponentConfig.Color(
+                            default = "textInverseWarningActive",
+                            states = emptyList(),
+                        ),
+                        backgroundColor = ButtonComponentConfig.Color(
+                            default = "surfaceInverseWarningActive",
+                            states = listOf(
+                                ButtonComponentConfig.ColorState(
+                                    listOf("pressed", "focused"),
+                                    "surfaceInverseWarningPressed",
+                                ),
+                            ),
+                        ),
+                        valueColor = ButtonComponentConfig.Color(
+                            default = "textInversePrimaryActive",
+                            states = emptyList(),
+                        ),
+                    ),
+                ),
             ),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/components/button/IconButtonStyleGeneratorComposeTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/components/button/IconButtonStyleGeneratorComposeTest.kt
@@ -114,7 +114,38 @@ class IconButtonStyleGeneratorComposeTest {
                         spinnerSize = 22f,
                     ),
                 ),
-                color = emptyMap(),
+                color = mapOf(
+                    "default" to ButtonComponentConfig.ColorScheme(
+                        contentColor = ButtonComponentConfig.Color(
+                            default = "textInversePrimaryActive",
+                            states = emptyList(),
+                        ),
+                        backgroundColor = ButtonComponentConfig.Color(
+                            default = "surfaceInversePrimaryActive",
+                            states = listOf(
+                                ButtonComponentConfig.ColorState(
+                                    listOf("pressed", "focused"),
+                                    "surfaceInversePrimaryPressed",
+                                ),
+                            ),
+                        ),
+                    ),
+                    "warning" to ButtonComponentConfig.ColorScheme(
+                        contentColor = ButtonComponentConfig.Color(
+                            default = "textInverseWarningActive",
+                            states = emptyList(),
+                        ),
+                        backgroundColor = ButtonComponentConfig.Color(
+                            default = "surfaceInverseWarningActive",
+                            states = listOf(
+                                ButtonComponentConfig.ColorState(
+                                    listOf("pressed", "focused"),
+                                    "surfaceInverseWarningPressed",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
             ),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/components/button/LinkButtonStyleGeneratorComposeTest.kt
+++ b/sdds-core/plugin_theme_builder/src/test/kotlin/com/sdds/plugin/themebuilder/internal/components/button/LinkButtonStyleGeneratorComposeTest.kt
@@ -123,7 +123,25 @@ class LinkButtonStyleGeneratorComposeTest {
                         valueMargin = 4f,
                     ),
                 ),
-                color = emptyMap(),
+                color = mapOf(
+                    "default" to ButtonComponentConfig.ColorScheme(
+                        contentColor = ButtonComponentConfig.Color(
+                            default = "textInversePrimaryActive",
+                            states = listOf(
+                                ButtonComponentConfig.ColorState(
+                                    listOf("pressed"),
+                                    "surfaceInversePrimaryPressed",
+                                ),
+                            ),
+                        ),
+                    ),
+                    "warning" to ButtonComponentConfig.ColorScheme(
+                        contentColor = ButtonComponentConfig.Color(
+                            default = "textInverseWarningActive",
+                            states = emptyList(),
+                        ),
+                    ),
+                ),
             ),
         )
     }

--- a/sdds-core/plugin_theme_builder/src/test/resources/component-outputs/BasicButtonStylesKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/component-outputs/BasicButtonStylesKt.txt
@@ -7,6 +7,8 @@ import com.sdds.compose.uikit.BasicButton
 import com.sdds.compose.uikit.BasicButtonStyleBuilder
 import com.sdds.compose.uikit.Button
 import com.sdds.compose.uikit.adjustBy
+import com.sdds.compose.uikit.interactions.InteractiveState
+import com.sdds.compose.uikit.interactions.asInteractive
 import com.sdds.playground.themebuilder.theme.SddsServTheme
 
 public val BasicButton.L: BasicButtonStyleBuilder
@@ -71,3 +73,24 @@ public val BasicButton.S: BasicButtonStyleBuilder
         )
         .labelStyle(SddsServTheme.typography.bodySBold)
         .valueStyle(SddsServTheme.typography.bodySBold)
+
+public val BasicButtonStyleBuilder.Default: BasicButtonStyleBuilder
+    @Composable
+    get() = this.colors {
+        contentColor(SddsServTheme.colors.textInversePrimaryActive.asInteractive(setOf(InteractiveState.Pressed)
+                to SddsServTheme.colors.surfaceInversePrimaryPressed))
+        backgroundColor(SddsServTheme.colors.surfaceInversePrimaryActive.asInteractive(setOf(InteractiveState.Pressed,
+                InteractiveState.Focused) to SddsServTheme.colors.surfaceInversePrimaryPressed))
+        valueColor(SddsServTheme.colors.textInversePrimaryActive.asInteractive())
+        spinnerMode(Button.SpinnerMode.SemitransparentContent(0.02f))
+    }
+
+public val BasicButtonStyleBuilder.Warning: BasicButtonStyleBuilder
+    @Composable
+    get() = this.colors {
+        contentColor(SddsServTheme.colors.textInverseWarningActive.asInteractive())
+        backgroundColor(SddsServTheme.colors.surfaceInverseWarningActive.asInteractive(setOf(InteractiveState.Pressed,
+                InteractiveState.Focused) to SddsServTheme.colors.surfaceInverseWarningPressed))
+        valueColor(SddsServTheme.colors.textInversePrimaryActive.asInteractive())
+        spinnerMode(Button.SpinnerMode.SemitransparentContent(0.02f))
+    }

--- a/sdds-core/plugin_theme_builder/src/test/resources/component-outputs/IconButtonStylesKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/component-outputs/IconButtonStylesKt.txt
@@ -7,6 +7,8 @@ import com.sdds.compose.uikit.Button
 import com.sdds.compose.uikit.IconButton
 import com.sdds.compose.uikit.IconButtonStyleBuilder
 import com.sdds.compose.uikit.adjustBy
+import com.sdds.compose.uikit.interactions.InteractiveState
+import com.sdds.compose.uikit.interactions.asInteractive
 import com.sdds.playground.themebuilder.theme.SddsServTheme
 
 public val IconButton.L: IconButtonStyleBuilder
@@ -59,3 +61,21 @@ public val IconButton.S: IconButtonStyleBuilder
                 spinnerSize = 22.0.dp,
             ),
         )
+
+public val IconButtonStyleBuilder.Default: IconButtonStyleBuilder
+    @Composable
+    get() = this.colors {
+        contentColor(SddsServTheme.colors.textInversePrimaryActive.asInteractive())
+        backgroundColor(SddsServTheme.colors.surfaceInversePrimaryActive.asInteractive(setOf(InteractiveState.Pressed,
+                InteractiveState.Focused) to SddsServTheme.colors.surfaceInversePrimaryPressed))
+        spinnerMode(Button.SpinnerMode.SemitransparentContent(0.02f))
+    }
+
+public val IconButtonStyleBuilder.Warning: IconButtonStyleBuilder
+    @Composable
+    get() = this.colors {
+        contentColor(SddsServTheme.colors.textInverseWarningActive.asInteractive())
+        backgroundColor(SddsServTheme.colors.surfaceInverseWarningActive.asInteractive(setOf(InteractiveState.Pressed,
+                InteractiveState.Focused) to SddsServTheme.colors.surfaceInverseWarningPressed))
+        spinnerMode(Button.SpinnerMode.SemitransparentContent(0.02f))
+    }

--- a/sdds-core/plugin_theme_builder/src/test/resources/component-outputs/LinkButtonStylesKt.txt
+++ b/sdds-core/plugin_theme_builder/src/test/resources/component-outputs/LinkButtonStylesKt.txt
@@ -7,6 +7,8 @@ import com.sdds.compose.uikit.Button
 import com.sdds.compose.uikit.LinkButton
 import com.sdds.compose.uikit.LinkButtonStyleBuilder
 import com.sdds.compose.uikit.adjustBy
+import com.sdds.compose.uikit.interactions.InteractiveState
+import com.sdds.compose.uikit.interactions.asInteractive
 import com.sdds.playground.themebuilder.theme.SddsServTheme
 
 public val LinkButton.L: LinkButtonStyleBuilder
@@ -62,3 +64,18 @@ public val LinkButton.S: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(SddsServTheme.typography.bodySBold)
+
+public val LinkButtonStyleBuilder.Default: LinkButtonStyleBuilder
+    @Composable
+    get() = this.colors {
+        contentColor(SddsServTheme.colors.textInversePrimaryActive.asInteractive(setOf(InteractiveState.Pressed)
+                to SddsServTheme.colors.surfaceInversePrimaryPressed))
+        spinnerMode(Button.SpinnerMode.SemitransparentContent(0.02f))
+    }
+
+public val LinkButtonStyleBuilder.Warning: LinkButtonStyleBuilder
+    @Composable
+    get() = this.colors {
+        contentColor(SddsServTheme.colors.textInverseWarningActive.asInteractive())
+        spinnerMode(Button.SpinnerMode.SemitransparentContent(0.02f))
+    }

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/BasicButtonStyleBuilder.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/BasicButtonStyleBuilder.kt
@@ -62,13 +62,6 @@ interface BasicButtonStyleBuilder : StyleBuilder<ButtonStyle> {
      */
     fun disableAlpha(disableAlpha: Float): BasicButtonStyleBuilder
 
-    /**
-     * Устанавливает режим работы индикатора загрузки [spinnerMode]
-     * @see ButtonStyle.spinnerMode
-     * @see Button.SpinnerMode
-     */
-    fun spinnerMode(spinnerMode: Button.SpinnerMode): BasicButtonStyleBuilder
-
     companion object {
         /**
          * Возвращает экземпляр [BasicButtonStyleBuilder]
@@ -173,6 +166,13 @@ interface BasicButtonColorsBuilder {
         spinnerColor(spinnerColor.asInteractive())
 
     /**
+     * Устанавливает режим работы индикатора загрузки [spinnerMode]
+     * @see ButtonColors.spinnerMode
+     * @see Button.SpinnerMode
+     */
+    fun spinnerMode(spinnerMode: Button.SpinnerMode): BasicButtonColorsBuilder
+
+    /**
      * Возвращает готовый экземпляр [ButtonColors]
      */
     fun build(): ButtonColors
@@ -193,7 +193,6 @@ private class BasicButtonStyleBuilderImpl(override val receiver: Any?) : BasicBu
     private var valueStyle: TextStyle? = null
     private var dimensions: Button.Dimensions? = null
     private var disableAlpha: Float? = null
-    private var spinnerMode: Button.SpinnerMode? = null
 
     override fun shape(shape: CornerBasedShape) = apply {
         this.shape = shape
@@ -220,10 +219,6 @@ private class BasicButtonStyleBuilderImpl(override val receiver: Any?) : BasicBu
         this.disableAlpha = disableAlpha
     }
 
-    override fun spinnerMode(spinnerMode: Button.SpinnerMode) = apply {
-        this.spinnerMode = spinnerMode
-    }
-
     override fun style(): ButtonStyle {
         return DefaultButtonStyle(
             shape = shape ?: RoundedCornerShape(25),
@@ -232,7 +227,6 @@ private class BasicButtonStyleBuilderImpl(override val receiver: Any?) : BasicBu
             valueStyle = valueStyle ?: TextStyle.Default,
             dimensions = dimensions ?: Button.Dimensions(),
             disableAlpha = disableAlpha ?: DISABLED_BUTTON_ALPHA,
-            spinnerMode = spinnerMode ?: Button.SpinnerMode.HideContent,
         )
     }
 }
@@ -245,6 +239,7 @@ private class DefaultBasicButtonColors(
     override val valueColor: InteractiveColor,
     override val iconColor: InteractiveColor,
     override val spinnerColor: InteractiveColor,
+    override val spinnerMode: Button.SpinnerMode,
 ) : ButtonColors {
 
     class Builder : BasicButtonColorsBuilder {
@@ -254,6 +249,7 @@ private class DefaultBasicButtonColors(
         private var valueColor: InteractiveColor? = null
         private var iconColor: InteractiveColor? = null
         private var spinnerColor: InteractiveColor? = null
+        private var spinnerMode: Button.SpinnerMode? = null
 
         override fun contentColor(contentColor: InteractiveColor) = apply {
             this.contentColor = contentColor
@@ -279,6 +275,10 @@ private class DefaultBasicButtonColors(
             this.spinnerColor = spinnerColor
         }
 
+        override fun spinnerMode(spinnerMode: Button.SpinnerMode) = apply {
+            this.spinnerMode = spinnerMode
+        }
+
         override fun build(): ButtonColors {
             val contentColor = contentColor ?: Color.Black.asInteractive()
             return DefaultBasicButtonColors(
@@ -288,6 +288,7 @@ private class DefaultBasicButtonColors(
                 valueColor = valueColor ?: contentColor,
                 iconColor = iconColor ?: contentColor,
                 spinnerColor = spinnerColor ?: contentColor,
+                spinnerMode = spinnerMode ?: Button.SpinnerMode.HideContent,
             )
         }
     }

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/Button.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/Button.kt
@@ -108,7 +108,7 @@ fun Button(
         modifier = modifier,
         onClick = onClick,
         colors = colors,
-        spinnerMode = style.spinnerMode,
+        spinnerMode = colors.spinnerMode,
         enabledAlpha = ENABLED_BUTTON_ALPHA,
         disabledAlpha = style.disableAlpha,
         enabled = enabled,

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/ButtonStyles.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/ButtonStyles.kt
@@ -105,6 +105,13 @@ interface ButtonColorsBuilder {
         spinnerColor(spinnerColor.asInteractive())
 
     /**
+     * Устанавливает режим работы индикатора загрузки [spinnerMode]
+     * @see ButtonColors.spinnerMode
+     * @see Button.SpinnerMode
+     */
+    fun spinnerMode(spinnerMode: Button.SpinnerMode): ButtonColorsBuilder
+
+    /**
      * Возвращает готовый экземпляр [ButtonColors]
      */
     fun build(): ButtonColors
@@ -150,12 +157,6 @@ interface ButtonStyle : Style {
      * Значение прозрачности выключенной кнопки
      */
     val disableAlpha: Float
-
-    /**
-     * Режим работы индикатора загрузки
-     * @see Button.SpinnerMode
-     */
-    val spinnerMode: Button.SpinnerMode
 }
 
 /**
@@ -200,6 +201,12 @@ interface ButtonColors {
      */
     val spinnerColor: InteractiveColor
 
+    /**
+     * Режим работы индикатора загрузки
+     * @see Button.SpinnerMode
+     */
+    val spinnerMode: Button.SpinnerMode
+
     companion object {
 
         /**
@@ -217,6 +224,7 @@ private class DefaultButtonColors(
     override val valueColor: InteractiveColor,
     override val iconColor: InteractiveColor,
     override val spinnerColor: InteractiveColor,
+    override val spinnerMode: Button.SpinnerMode,
 ) : ButtonColors {
 
     class Builder : ButtonColorsBuilder {
@@ -226,6 +234,7 @@ private class DefaultButtonColors(
         private var valueColor: InteractiveColor? = null
         private var iconColor: InteractiveColor? = null
         private var spinnerColor: InteractiveColor? = null
+        private var spinnerMode: Button.SpinnerMode? = null
 
         override fun contentColor(contentColor: InteractiveColor) = apply {
             this.contentColor = contentColor
@@ -251,6 +260,10 @@ private class DefaultButtonColors(
             this.spinnerColor = spinnerColor
         }
 
+        override fun spinnerMode(spinnerMode: Button.SpinnerMode) = apply {
+            this.spinnerMode = spinnerMode
+        }
+
         override fun build(): ButtonColors {
             val contentColor = contentColor ?: Color.Black.asInteractive()
             return DefaultButtonColors(
@@ -260,6 +273,7 @@ private class DefaultButtonColors(
                 valueColor = valueColor ?: contentColor,
                 iconColor = iconColor ?: contentColor,
                 spinnerColor = spinnerColor ?: contentColor,
+                spinnerMode = spinnerMode ?: Button.SpinnerMode.HideContent,
             )
         }
     }
@@ -273,5 +287,4 @@ internal class DefaultButtonStyle(
     override val valueStyle: TextStyle,
     override val dimensions: Button.Dimensions,
     override val disableAlpha: Float,
-    override val spinnerMode: Button.SpinnerMode,
 ) : ButtonStyle

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/IconButtonStyleBuilder.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/IconButtonStyleBuilder.kt
@@ -50,13 +50,6 @@ interface IconButtonStyleBuilder : StyleBuilder<ButtonStyle> {
      */
     fun disableAlpha(disableAlpha: Float): IconButtonStyleBuilder
 
-    /**
-     * Устанавливает режим работы индикатора загрузки [spinnerMode]
-     * @see ButtonStyle.spinnerMode
-     * @see Button.SpinnerMode
-     */
-    fun spinnerMode(spinnerMode: Button.SpinnerMode): IconButtonStyleBuilder
-
     companion object {
         /**
          * Возвращает экземпляр [IconButtonStyleBuilder]
@@ -131,6 +124,13 @@ interface IconButtonColorsBuilder {
         spinnerColor(spinnerColor.asInteractive())
 
     /**
+     * Устанавливает режим работы индикатора загрузки [spinnerMode]
+     * @see ButtonColors.spinnerMode
+     * @see Button.SpinnerMode
+     */
+    fun spinnerMode(spinnerMode: Button.SpinnerMode): IconButtonColorsBuilder
+
+    /**
      * Возвращает готовый экземпляр [ButtonColors]
      */
     fun build(): ButtonColors
@@ -151,7 +151,6 @@ private class IconButtonStyleBuilderImpl(override val receiver: Any?) : IconButt
     private var valueStyle: TextStyle? = null
     private var dimensions: Button.Dimensions? = null
     private var disableAlpha: Float? = null
-    private var spinnerMode: Button.SpinnerMode? = null
 
     override fun shape(shape: CornerBasedShape) = apply {
         this.shape = shape
@@ -170,10 +169,6 @@ private class IconButtonStyleBuilderImpl(override val receiver: Any?) : IconButt
         this.disableAlpha = disableAlpha
     }
 
-    override fun spinnerMode(spinnerMode: Button.SpinnerMode) = apply {
-        this.spinnerMode = spinnerMode
-    }
-
     override fun style(): ButtonStyle {
         return DefaultButtonStyle(
             shape = shape ?: RoundedCornerShape(25),
@@ -182,7 +177,6 @@ private class IconButtonStyleBuilderImpl(override val receiver: Any?) : IconButt
             valueStyle = valueStyle ?: TextStyle.Default,
             dimensions = dimensions ?: Button.Dimensions(),
             disableAlpha = disableAlpha ?: DISABLED_BUTTON_ALPHA,
-            spinnerMode = spinnerMode ?: Button.SpinnerMode.HideContent,
         )
     }
 }
@@ -195,6 +189,7 @@ private class DefaultIconButtonColors(
     override val valueColor: InteractiveColor,
     override val iconColor: InteractiveColor,
     override val spinnerColor: InteractiveColor,
+    override val spinnerMode: Button.SpinnerMode,
 ) : ButtonColors {
 
     class Builder : IconButtonColorsBuilder {
@@ -204,6 +199,7 @@ private class DefaultIconButtonColors(
         private var valueColor: InteractiveColor? = null
         private var iconColor: InteractiveColor? = null
         private var spinnerColor: InteractiveColor? = null
+        private var spinnerMode: Button.SpinnerMode? = null
 
         override fun contentColor(contentColor: InteractiveColor) = apply {
             this.contentColor = contentColor
@@ -221,6 +217,10 @@ private class DefaultIconButtonColors(
             this.spinnerColor = spinnerColor
         }
 
+        override fun spinnerMode(spinnerMode: Button.SpinnerMode) = apply {
+            this.spinnerMode = spinnerMode
+        }
+
         override fun build(): ButtonColors {
             val contentColor = contentColor ?: Color.Black.asInteractive()
             return DefaultIconButtonColors(
@@ -230,6 +230,7 @@ private class DefaultIconButtonColors(
                 valueColor = valueColor ?: contentColor,
                 iconColor = iconColor ?: contentColor,
                 spinnerColor = spinnerColor ?: contentColor,
+                spinnerMode = spinnerMode ?: Button.SpinnerMode.HideContent,
             )
         }
     }

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/LinkButtonStyleBuilder.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/LinkButtonStyleBuilder.kt
@@ -56,13 +56,6 @@ interface LinkButtonStyleBuilder : StyleBuilder<ButtonStyle> {
      */
     fun disableAlpha(disableAlpha: Float): LinkButtonStyleBuilder
 
-    /**
-     * Устанавливает режим работы индикатора загрузки [spinnerMode]
-     * @see ButtonStyle.spinnerMode
-     * @see Button.SpinnerMode
-     */
-    fun spinnerMode(spinnerMode: Button.SpinnerMode): LinkButtonStyleBuilder
-
     companion object {
         /**
          * Возвращает экземпляр [LinkButtonStyleBuilder]
@@ -159,6 +152,13 @@ interface LinkButtonColorsBuilder {
     fun spinnerColor(spinnerColor: InteractiveColor): LinkButtonColorsBuilder
 
     /**
+     * Устанавливает режим работы индикатора загрузки [spinnerMode]
+     * @see ButtonColors.spinnerMode
+     * @see Button.SpinnerMode
+     */
+    fun spinnerMode(spinnerMode: Button.SpinnerMode): LinkButtonColorsBuilder
+
+    /**
      * Устанавливает цвет индикатора загрузки кнопки [spinnerColor]
      * @see ButtonColors.spinnerColor
      * @see InteractiveColor
@@ -187,7 +187,6 @@ private class LinkButtonStyleBuilderImpl(override val receiver: Any?) : LinkButt
     private var valueStyle: TextStyle? = null
     private var dimensions: Button.Dimensions? = null
     private var disableAlpha: Float? = null
-    private var spinnerMode: Button.SpinnerMode? = null
 
     override fun shape(shape: CornerBasedShape) = apply {
         this.shape = shape
@@ -214,10 +213,6 @@ private class LinkButtonStyleBuilderImpl(override val receiver: Any?) : LinkButt
         this.disableAlpha = disableAlpha
     }
 
-    override fun spinnerMode(spinnerMode: Button.SpinnerMode) = apply {
-        this.spinnerMode = spinnerMode
-    }
-
     override fun style(): ButtonStyle {
         return DefaultButtonStyle(
             shape = shape ?: RoundedCornerShape(25),
@@ -226,7 +221,6 @@ private class LinkButtonStyleBuilderImpl(override val receiver: Any?) : LinkButt
             valueStyle = valueStyle ?: TextStyle.Default,
             dimensions = dimensions ?: Button.Dimensions(),
             disableAlpha = disableAlpha ?: DISABLED_BUTTON_ALPHA,
-            spinnerMode = spinnerMode ?: Button.SpinnerMode.HideContent,
         )
     }
 }
@@ -239,6 +233,7 @@ private class DefaultLinkButtonColors(
     override val valueColor: InteractiveColor,
     override val iconColor: InteractiveColor,
     override val spinnerColor: InteractiveColor,
+    override val spinnerMode: Button.SpinnerMode,
 ) : ButtonColors {
 
     class Builder : LinkButtonColorsBuilder {
@@ -248,6 +243,7 @@ private class DefaultLinkButtonColors(
         private var valueColor: InteractiveColor? = null
         private var iconColor: InteractiveColor? = null
         private var spinnerColor: InteractiveColor? = null
+        private var spinnerMode: Button.SpinnerMode? = null
 
         override fun contentColor(contentColor: InteractiveColor) = apply {
             this.contentColor = contentColor
@@ -273,6 +269,10 @@ private class DefaultLinkButtonColors(
             this.spinnerColor = spinnerColor
         }
 
+        override fun spinnerMode(spinnerMode: Button.SpinnerMode) = apply {
+            this.spinnerMode = spinnerMode
+        }
+
         override fun build(): ButtonColors {
             val contentColor = contentColor ?: Color.Black.asInteractive()
             return DefaultLinkButtonColors(
@@ -282,6 +282,7 @@ private class DefaultLinkButtonColors(
                 valueColor = valueColor ?: contentColor,
                 iconColor = iconColor ?: contentColor,
                 spinnerColor = spinnerColor ?: contentColor,
+                spinnerMode = spinnerMode ?: Button.SpinnerMode.HideContent,
             )
         }
     }

--- a/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/button/link/LinkButtonStyles.kt
+++ b/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/button/link/LinkButtonStyles.kt
@@ -66,9 +66,9 @@ val LinkButton.L: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(PlasmaSdServiceTheme.typography.bodyLBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(PlasmaSdServiceTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 val LinkButton.M: LinkButtonStyleBuilder
@@ -85,9 +85,9 @@ val LinkButton.M: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(PlasmaSdServiceTheme.typography.bodyMBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(PlasmaSdServiceTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 val LinkButton.S: LinkButtonStyleBuilder
@@ -104,9 +104,9 @@ val LinkButton.S: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(PlasmaSdServiceTheme.typography.bodySBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(PlasmaSdServiceTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 val LinkButton.Xs: LinkButtonStyleBuilder
@@ -123,9 +123,9 @@ val LinkButton.Xs: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(PlasmaSdServiceTheme.typography.bodyXsBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(PlasmaSdServiceTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 @Composable

--- a/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/button/link/LinkButtonStyles.kt
+++ b/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/button/link/LinkButtonStyles.kt
@@ -66,9 +66,9 @@ val LinkButton.L: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(SddsServTheme.typography.bodyLBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(SddsServTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 val LinkButton.M: LinkButtonStyleBuilder
@@ -85,9 +85,9 @@ val LinkButton.M: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(SddsServTheme.typography.bodyMBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(SddsServTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 val LinkButton.S: LinkButtonStyleBuilder
@@ -104,9 +104,9 @@ val LinkButton.S: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(SddsServTheme.typography.bodySBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(SddsServTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 val LinkButton.Xs: LinkButtonStyleBuilder
@@ -123,9 +123,9 @@ val LinkButton.Xs: LinkButtonStyleBuilder
             ),
         )
         .labelStyle(SddsServTheme.typography.bodyXsBold)
-        .spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         .colors {
             backgroundColor(SddsServTheme.colors.surfaceDefaultClear)
+            spinnerMode(Button.SpinnerMode.SemitransparentContent(SEMITRANSPARENT_SPINNER_ALPHA))
         }
 
 @Composable


### PR DESCRIPTION
* Реализована генерация вариаций цвета кнопок на Cоmpose
* spinnerMode перенесен из билдера стиля в билдер цвета, т.к. режим спиннера напрямую зависит от цвета, но не от размера