### PR TITLE
feat(sdds-acore/uikit-compose): fix inner tf focus

### DIFF
--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/compose/ComposeTextAreaScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/compose/ComposeTextAreaScreenshotTest.kt
@@ -1,6 +1,6 @@
 package com.sdds.playground.sandbox.compose
 
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.sdds.playground.sandbox.textfield.compose.SandboxTextAreaPreviewLDefaultInnerLeft
@@ -109,8 +109,9 @@ class ComposeTextAreaScreenshotTest(
         composeTestRule.setContent {
             SandboxTextAreaPreviewSWarningInnerRightFocused()
         }
-        composeTestRule.onNodeWithText("Placeholder")
+        composeTestRule.onNodeWithTag("textField")
             .performClick()
+        composeTestRule.mainClock.advanceTimeByFrame()
     }
 
     @Test

--- a/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/compose/ComposeTextFieldScreenshotTest.kt
+++ b/playground/sandbox-compose/src/test/kotlin/com/sdds/playground/sandbox/compose/ComposeTextFieldScreenshotTest.kt
@@ -1,6 +1,6 @@
 package com.sdds.playground.sandbox.compose
 
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
@@ -113,8 +113,9 @@ class ComposeTextFieldScreenshotTest(
         composeTestRule.setContent {
             SandboxTextFieldPreviewSWarningInnerLabelRightFocused()
         }
-        composeTestRule.onNodeWithText("Placeholder")
+        composeTestRule.onNodeWithTag("textField")
             .performClick()
+        composeTestRule.onNodeWithTag("innerTextField")
             .performTextInput("Value")
     }
 
@@ -137,8 +138,9 @@ class ComposeTextFieldScreenshotTest(
         composeTestRule.setContent {
             SandboxTextFieldPreviewLInputText()
         }
-        composeTestRule.onNodeWithText("Placeholder")
+        composeTestRule.onNodeWithTag("textField")
             .performClick()
+        composeTestRule.onNodeWithTag("innerTextField")
             .performTextInput("абвгдежзabcdefg@#643!#\$")
     }
 

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/common/Modifiers.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/common/Modifiers.kt
@@ -2,6 +2,7 @@ package com.sdds.compose.uikit.internal.common
 
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CornerBasedShape
@@ -89,7 +90,7 @@ internal fun Modifier.surface(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource,
 ): Modifier {
-    val clickableModifier = onClick?.let {
+    val clickableOrFocusableModifier = onClick?.let {
         Modifier.clickable(
             interactionSource = interactionSource,
             indication = indication,
@@ -97,10 +98,10 @@ internal fun Modifier.surface(
             role = role,
             onClick = onClick,
         )
-    } ?: Modifier
+    } ?: Modifier.focusable(enabled, interactionSource)
 
     return clip(shape)
-        .then(clickableModifier)
+        .then(clickableOrFocusableModifier)
         .graphicsLayer { this.alpha = alpha(enabled) }
         .drawBehind {
             drawRect(backgroundColor())
@@ -131,7 +132,7 @@ internal fun Modifier.surface(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource,
 ): Modifier {
-    val toggleableModifier = onValueChange?.let {
+    val toggleableOrFocusableModifier = onValueChange?.let {
         Modifier.toggleable(
             value = value,
             interactionSource = interactionSource,
@@ -140,10 +141,10 @@ internal fun Modifier.surface(
             role = role,
             onValueChange = onValueChange,
         )
-    } ?: Modifier
+    } ?: Modifier.focusable(enabled, interactionSource)
 
     return clip(shape)
-        .then(toggleableModifier)
+        .then(toggleableOrFocusableModifier)
         .graphicsLayer { this.alpha = alpha(enabled) }
         .drawBehind {
             drawRect(backgroundColor())

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/DecorationBox.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/DecorationBox.kt
@@ -14,8 +14,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.semantics.error
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
@@ -27,10 +25,10 @@ import com.sdds.compose.uikit.TextField
  */
 @Composable
 internal fun DecorationBox(
+    modifier: Modifier,
     value: String,
     singleLine: Boolean,
     isClearAppearance: Boolean,
-    isError: Boolean = false,
     innerLabel: @Composable (() -> Unit)?,
     innerOptional: @Composable (() -> Unit)?,
     chips: @Composable (() -> Unit)? = null,
@@ -61,9 +59,6 @@ internal fun DecorationBox(
         else -> InputPhase.UnfocusedNotEmpty
     }
 
-    val decorationBoxModifier = Modifier
-        .semantics { if (isError) error("") }
-
     TextFieldTransitionScope.Transition(
         inputState = inputState,
         showLabel = innerLabel != null || innerOptional != null,
@@ -82,7 +77,7 @@ internal fun DecorationBox(
         }
 
         TextFieldLayout(
-            modifier = decorationBoxModifier,
+            modifier = modifier,
             textField = innerTextField,
             verticalScrollState = verticalScrollState,
             horizontalScrollState = horizontalScrollState,

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/TextFieldLayout.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/TextFieldLayout.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,6 +44,8 @@ import androidx.compose.ui.unit.offset
 import com.sdds.compose.uikit.ChipGroup
 import com.sdds.compose.uikit.ChipGroupStyle
 import com.sdds.compose.uikit.TextField
+import com.sdds.compose.uikit.internal.focusselector.FocusSelectorMode
+import com.sdds.compose.uikit.internal.focusselector.LocalFocusSelectorMode
 import com.sdds.compose.uikit.internal.heightOrZero
 import com.sdds.compose.uikit.internal.widthOrZero
 import kotlin.math.abs
@@ -257,24 +260,36 @@ private fun CompositeTextFieldContent(
             textField()
         }
     }
-    if (!singleLine) {
-        TextAreaContent(
-            modifier = modifier,
-            textContent = textContent,
-            chips = chips,
-            chipStyle = chipStyle,
-            dimensions = dimensions,
-            scrollState = verticalScrollState,
-        )
-    } else {
-        TextFieldContent(
-            modifier = modifier,
-            textContent = textContent,
-            chips = chips,
-            chipStyle = chipStyle,
-            dimensions = dimensions,
-            scrollState = horizontalScrollState,
-        )
+    CompositionLocalProvider(
+        // Принудительно уменьшаем бордер, чтобы он был в границах чипов
+        LocalFocusSelectorMode provides LocalFocusSelectorMode.current.reduceBorderPadding(),
+    ) {
+        if (!singleLine) {
+            TextAreaContent(
+                modifier = modifier,
+                textContent = textContent,
+                chips = chips,
+                chipStyle = chipStyle,
+                dimensions = dimensions,
+                scrollState = verticalScrollState,
+            )
+        } else {
+            TextFieldContent(
+                modifier = modifier,
+                textContent = textContent,
+                chips = chips,
+                chipStyle = chipStyle,
+                dimensions = dimensions,
+                scrollState = horizontalScrollState,
+            )
+        }
+    }
+}
+
+private fun FocusSelectorMode.reduceBorderPadding(): FocusSelectorMode {
+    return when (this) {
+        is FocusSelectorMode.Border -> copy(strokePadding = -borderStroke.width)
+        else -> this
     }
 }
 


### PR DESCRIPTION
* Убрал использование декоратора в системном BasicTextField, чтобы сделать focusable внутренние сущности DecorationBox. Вместо этого просто положил BasicTextField внутрь декоратора.
* Добавил логику установки фокуса в textField, если кликать по DecorationBox
* Доработал тесты с фокусным состоянием, добавил теги для внутреннего textField и для внешнего контейнера (DecorationBox)


https://github.com/user-attachments/assets/e8bff9ee-959c-42cb-a94a-00063766ae09


https://github.com/user-attachments/assets/d5b7ab4d-f7c8-4720-b75f-d74ef1340ee6

