### PR TITLE
ci: icon workflow was fixed

### DIFF
--- a/build-system/conventions/src/main/kotlin/utils/AutoBump.kt
+++ b/build-system/conventions/src/main/kotlin/utils/AutoBump.kt
@@ -2,6 +2,7 @@ package utils
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -74,7 +75,17 @@ abstract class AutoBumpTask : DefaultTask() {
     }
 
     private fun Project.cacheBumpInfo(versionBump: VersionBump) {
-        layout.buildDirectory.file(versionBumpFileName.get()).get().asFile.writeText(versionBump.name)
+        buildDirectory.file(versionBumpFileName.get()).get().asFile.writeText(versionBump.name)
     }
+
+    /**
+     * Создаст build директорию, если она не существует
+     */
+    private val Project.buildDirectory: DirectoryProperty
+        get() {
+            val buildDir = project.layout.buildDirectory.asFile.get()
+            if (!buildDir.exists()) project.mkdir("build")
+            return layout.buildDirectory
+        }
 }
 


### PR DESCRIPTION
Поправил воркфлоу апдейта иконок. Он не срабатывал, потому что в таске AutoBump появился новый функционал с кешированием версии в build директории, который не учитывал то, что build директория может не существовать

https://github.com/salute-developers/plasma-android/actions/workflows/generate-icons.yml