### PR TITLE
bugfix(sdds-acore/uikit): FocusSelecor

### DIFF
--- a/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/View.kt
+++ b/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/View.kt
@@ -1,0 +1,51 @@
+package com.sdds.uikit
+
+import android.content.Context
+import android.graphics.Rect
+import android.util.AttributeSet
+import com.sdds.uikit.internal.base.shape.ShapeHelper
+import com.sdds.uikit.internal.focusselector.FocusSelectorDelegate
+import com.sdds.uikit.internal.focusselector.HasFocusSelector
+import com.sdds.uikit.shape.ShapeModel
+import com.sdds.uikit.shape.Shapeable
+import com.sdds.uikit.shape.shapeHelper
+import android.view.View as AndroidView
+
+/**
+ * Реализация [android.view.View] с поддержой селектора фокуса и [Shapeable]
+ * @param context контекст
+ * @param attrs аттрибуты view
+ * @param defStyleAttr аттрибут стиля по умолчанию
+ * @author Малышев Александр on 07.03.2025
+ */
+open class View @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : AndroidView(context, attrs, defStyleAttr), Shapeable, HasFocusSelector by FocusSelectorDelegate() {
+
+    private val _shapeable: ShapeHelper = shapeHelper(attrs, defStyleAttr)
+
+    /**
+     * @see Shapeable.shape
+     */
+    override val shape: ShapeModel?
+        get() = _shapeable.shape
+
+    init {
+        @Suppress("LeakingThis")
+        applySelector(this, context, attrs, defStyleAttr)
+    }
+
+    override fun onFocusChanged(gainFocus: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
+        updateFocusSelector(this, gainFocus)
+    }
+
+    override fun setPressed(pressed: Boolean) {
+        if (isPressed != pressed) {
+            handlePressedChange(this, pressed)
+        }
+        super.setPressed(pressed)
+    }
+}

--- a/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/internal/focusselector/HasFocusSelector.kt
+++ b/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/internal/focusselector/HasFocusSelector.kt
@@ -61,7 +61,11 @@ internal class FocusSelectorDelegate : HasFocusSelector {
         )
         try {
             mode = FocusSelectorMode.fromAttr(attr)
-            if (!mode.isEnabled() || !view.isFocusable) return
+            val duplicateParentStateEnabled = attr.getBoolean(
+                R.styleable.SdFocusSelector_sd_fsDuplicateParentState,
+                false,
+            )
+            if (!mode.isEnabled() || !view.canBeFocusable(duplicateParentStateEnabled)) return
             if (mode == FocusSelectorMode.SCALE) {
                 val factor = attr.getFloat(
                     R.styleable.SdFocusSelector_sd_fsScaleFactor,
@@ -105,6 +109,10 @@ internal class FocusSelectorDelegate : HasFocusSelector {
         if (mode == FocusSelectorMode.SCALE) {
             scaleAnimationHelper?.animatePressedState(view, isPressed)
         }
+    }
+
+    private fun View.canBeFocusable(duplicateStateEnabled: Boolean): Boolean {
+        return isFocusable || (duplicateStateEnabled && isDuplicateParentStateEnabled)
     }
 
     private fun View.tryApplyStrokeSelector(

--- a/sdds-core/uikit/src/main/res/values/base_attrs.xml
+++ b/sdds-core/uikit/src/main/res/values/base_attrs.xml
@@ -14,6 +14,7 @@
     <attr name="sd_fsStrokeInset" format="dimension" />
     <attr name="sd_fsShapeAppearance" format="reference" />
     <attr name="sd_fsShapeAdjustment" format="dimension" />
+    <attr name="sd_fsDuplicateParentState" format="boolean"/>
 
     <attr name="sd_shapeAppearance" format="reference" />
     <attr name="sd_shaderAppearance" format="reference" />
@@ -106,6 +107,7 @@
         <attr name="sd_fsStrokeWidth" />
         <attr name="sd_fsStrokeInset" />
         <attr name="sd_fsShapeAppearance" />
+        <attr name="sd_fsDuplicateParentState" />
     </declare-styleable>
 
     <declare-styleable name="SdViewState">


### PR DESCRIPTION
FocusSelecor now can respect duplicateParentState attribute of view.