### PR TITLE
fix(sdds-acore/uikit):Bug with extra space between right content and …

### DIFF
--- a/sdds-core/testing/src/main/kotlin/com/sdds/testing/vs/cell/CellUiState.kt
+++ b/sdds-core/testing/src/main/kotlin/com/sdds/testing/vs/cell/CellUiState.kt
@@ -22,7 +22,7 @@ data class CellUiState(
     val label: String = "Label",
     val title: String = "Title",
     val subtitle: String = "Subtitle",
-    val hasDisclosure: Boolean = true,
+    val hasDisclosure: Boolean = false,
     val disclosureText: String = "",
     val startContent: CellContent = CellContent.AVATAR,
     val endContent: CellContent = CellContent.NONE,

--- a/sdds-core/uikit/src/main/res/values/cell_layout_attrs.xml
+++ b/sdds-core/uikit/src/main/res/values/cell_layout_attrs.xml
@@ -18,6 +18,7 @@
         <attr name="sd_subtitleColor" format="color" />
 
         <attr name="sd_disclosureEnabled" format="boolean" />
+        <attr name="sd_disclosurePadding" format="dimension" />
         <attr name="sd_disclosureText" format="string" />
         <attr name="sd_disclosureTextAppearance" format="reference" />
         <attr name="sd_disclosureColor" format="color" />


### PR DESCRIPTION
…disclosure was fixed

на этом снимке задал у текста wrapContent чтобы было видно, что end и disclosure остаются в конце 
и добавил disclosurePadding 20dp
<img width="357" alt="Снимок экрана 2025-03-13 в 15 41 47" src="https://github.com/user-attachments/assets/da4aef75-951e-4339-9db6-c8bc19706f48" />

тут все стандартно - текст занимает matchParent
disclosurePadding 0dp
<img width="318" alt="Снимок экрана 2025-03-13 в 15 46 36" src="https://github.com/user-attachments/assets/8fc6f202-4ef3-4471-a0d5-0fe6cfe43af4" />

