### PR TITLE
fix(sdds-alibs): NavigationDrawer

### DIFF
--- a/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/activities/vs/SandboxActivity.kt
+++ b/playground/sandbox-compose/src/main/kotlin/com/sdds/playground/sandbox/activities/vs/SandboxActivity.kt
@@ -114,7 +114,11 @@ class SandboxActivity : AppCompatActivity() {
                     .build()
             },
         )
-        setSelected(navController.graph.startDestinationId)
+        val currentItem = items.find { it.componentKey == lastSelectedKey } ?: items.first()
+        if (currentItem.id != navController.graph.startDestinationId) {
+            onNavDestinationSelected(currentItem, navController)
+        }
+        setSelected(currentItem.id)
     }
 
     @Suppress("RestrictedApi")

--- a/tokens/plasma-stards-view/src/main/res/values/styles_navigation_drawer.xml
+++ b/tokens/plasma-stards-view/src/main/res/values/styles_navigation_drawer.xml
@@ -41,6 +41,6 @@
         <item name="sd_fsBorderMode">none</item>
         <item name="sd_collapsedCounterOffsetX">@dimen/sdkit_navigation_drawer_item_counter_offset_x</item>
         <item name="sd_collapsedCounterOffsetY">@dimen/sdkit_navigation_drawer_item_counter_offset_y</item>
-        <item name="sd_shapeColorAnimationEnabled">true</item>
+        <item name="sd_shapeColorAnimationEnabled">false</item>
     </style>
 </resources>

--- a/tokens/sdds.serv.view/src/main/res/values/styles_navigation_drawer.xml
+++ b/tokens/sdds.serv.view/src/main/res/values/styles_navigation_drawer.xml
@@ -41,6 +41,6 @@
         <item name="sd_fsBorderMode">none</item>
         <item name="sd_collapsedCounterOffsetX">@dimen/serv_navigation_drawer_item_counter_offset_x</item>
         <item name="sd_collapsedCounterOffsetY">@dimen/serv_navigation_drawer_item_counter_offset_y</item>
-        <item name="sd_shapeColorAnimationEnabled">true</item>
+        <item name="sd_shapeColorAnimationEnabled">false</item>
     </style>
 </resources>


### PR DESCRIPTION
- NavigationDrawer selection animation was disabled.
- Sandbox now can save and restore last fragment when switching themes.