### PR TITLE
fix(sdds-acore/uikit-compose): AccordionItem iconColor was fixed. TextField chips radius was fixed

### DIFF
--- a/build-system/gradle.properties
+++ b/build-system/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/playground/gradle.properties
+++ b/playground/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/sdds-core/gradle.properties
+++ b/sdds-core/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/AccordionItem.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/AccordionItem.kt
@@ -113,9 +113,7 @@ fun AccordionItem(
             ) { onClick.invoke() },
     ) {
         val iconContent: @Composable RowScope.() -> Unit = {
-            CompositionLocalProvider(
-                LocalTint provides style.colors.iconColor.colorForInteraction(interactionSource)
-            ) {
+            CompositionLocalProvider(LocalTint provides style.colors.iconColor.colorForInteraction(interactionSource)) {
                 action.invoke()
             }
         }
@@ -132,14 +130,8 @@ fun AccordionItem(
                 iconPadding = style.dimensions.iconPadding,
             ),
             title = AnnotatedString(title),
-            startContent = startContent(
-                iconContent = iconContent,
-                iconPlacement = style.iconPlacement,
-            ),
-            endContent = endContent(
-                iconContent = iconContent,
-                iconPlacement = style.iconPlacement,
-            ),
+            startContent = startContent(iconContent, style.iconPlacement),
+            endContent = endContent(iconContent, style.iconPlacement),
             gravity = CellGravity.Center,
             disclosureContentEnabled = false,
             disclosureIconRes = null,

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/AccordionItem.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/AccordionItem.kt
@@ -112,6 +112,13 @@ fun AccordionItem(
                 interactionSource = interactionSource,
             ) { onClick.invoke() },
     ) {
+        val iconContent: @Composable RowScope.() -> Unit = {
+            CompositionLocalProvider(
+                LocalTint provides style.colors.iconColor.colorForInteraction(interactionSource)
+            ) {
+                action.invoke()
+            }
+        }
         Cell(
             modifier = Modifier.padding(
                 start = style.dimensions.paddingStart,
@@ -125,8 +132,14 @@ fun AccordionItem(
                 iconPadding = style.dimensions.iconPadding,
             ),
             title = AnnotatedString(title),
-            startContent = startContent(action, style.iconPlacement),
-            endContent = endContent(action, style.iconPlacement),
+            startContent = startContent(
+                iconContent = iconContent,
+                iconPlacement = style.iconPlacement,
+            ),
+            endContent = endContent(
+                iconContent = iconContent,
+                iconPlacement = style.iconPlacement,
+            ),
             gravity = CellGravity.Center,
             disclosureContentEnabled = false,
             disclosureIconRes = null,
@@ -220,27 +233,21 @@ private fun AccordionAction(
 }
 
 private fun startContent(
-    action: @Composable () -> Unit,
+    iconContent: @Composable RowScope.() -> Unit,
     iconPlacement: AccordionIconPlacement,
 ): (@Composable RowScope.() -> Unit)? {
     return when (iconPlacement) {
-        AccordionIconPlacement.Start -> {
-            @Composable { action.invoke() }
-        }
-
+        AccordionIconPlacement.Start -> iconContent
         AccordionIconPlacement.End -> null
     }
 }
 
 private fun endContent(
-    action: @Composable () -> Unit,
+    iconContent: @Composable RowScope.() -> Unit,
     iconPlacement: AccordionIconPlacement,
 ): (@Composable RowScope.() -> Unit)? {
     return when (iconPlacement) {
-        AccordionIconPlacement.End -> {
-            @Composable { action.invoke() }
-        }
-
+        AccordionIconPlacement.End -> iconContent
         AccordionIconPlacement.Start -> null
     }
 }

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/TextFieldLayout.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/textfield/TextFieldLayout.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.unit.offset
 import com.sdds.compose.uikit.ChipGroup
 import com.sdds.compose.uikit.ChipGroupOverflowMode
 import com.sdds.compose.uikit.ChipGroupStyle
-import com.sdds.compose.uikit.LocalChipStyle
 import com.sdds.compose.uikit.TextFieldDimensions
 import com.sdds.compose.uikit.internal.focusselector.FocusSelectorMode
 import com.sdds.compose.uikit.internal.focusselector.LocalFocusSelectorMode
@@ -348,7 +347,7 @@ private fun TextFieldContent(
         modifier = modifier
             .fieldShapeDecoration(
                 hasChips = chips != null,
-                chipContainerShape = LocalChipStyle.current.shape,
+                chipContainerShape = chipGroupStyle.chipStyle.shape,
             )
             .then(scrollState?.let { Modifier.horizontalScroll(it) } ?: Modifier),
         content = {

--- a/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemClearActionEndStyles.kt
+++ b/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemClearActionEndStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemClearActionStartStyles.kt
+++ b/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemClearActionStartStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
+++ b/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
+++ b/tokens/plasma.giga.app.compose/src/main/kotlin/com/sdds/plasma/giga/app/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaAppTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemClearActionEndStyles.kt
+++ b/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemClearActionEndStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemClearActionStartStyles.kt
+++ b/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemClearActionStartStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
+++ b/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
+++ b/tokens/plasma.giga.compose/src/main/kotlin/com/sdds/plasma/giga/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaGigaTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemClearActionEndStyles.kt
+++ b/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemClearActionEndStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemClearActionStartStyles.kt
+++ b/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemClearActionStartStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
+++ b/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
+++ b/tokens/plasma.sd.service.compose/src/main/kotlin/com/sdds/plasma/sd/service/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                PlasmaSdServiceTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemClearActionEndStyles.kt
+++ b/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemClearActionEndStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 SddsServTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                SddsServTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemClearActionStartStyles.kt
+++ b/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemClearActionStartStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 SddsServTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                SddsServTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
+++ b/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 SddsServTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                SddsServTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
+++ b/tokens/sdds.serv.compose/src/main/kotlin/com/sdds/serv/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 SddsServTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                SddsServTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemClearActionEndStyles.kt
+++ b/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemClearActionEndStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemClearActionStartStyles.kt
+++ b/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemClearActionStartStyles.kt
@@ -100,6 +100,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)

--- a/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
+++ b/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemSolidActionEndStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .iconPlacement(AccordionIconPlacement.End)
         .iconRotation(90.0f)

--- a/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
+++ b/tokens/stylessalute.compose/src/main/kotlin/com/sdds/stylessalute/styles/accordionitem/AccordionItemSolidActionStartStyles.kt
@@ -104,6 +104,9 @@ private val AccordionItemStyleBuilder.invariantProps: AccordionItemStyleBuilder
             contentTextColor(
                 StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
             )
+            iconColor(
+                StylesSaluteTheme.colors.textDefaultPrimary.asInteractive(),
+            )
         }
         .dimensions {
             iconPadding(4.0.dp)


### PR DESCRIPTION
* Исправлено скругление контейнера чипов в textfield
* Добален iconColor в AccordionItem

<img width="1080" height="2400" alt="Screenshot_20250725_131912" src="https://github.com/user-attachments/assets/a973f36b-ef31-45d9-9d3d-39cc7845787f" />
<img width="1080" height="2400" alt="Screenshot_20250725_131817" src="https://github.com/user-attachments/assets/9e7490ed-5e51-4763-ae9f-18b5b0d5aeee" />
