### PR TITLE
PLASMA-5479: Displaying and assigning text through xml in IconBadge was fixed

### DIFF
--- a/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/Badge.kt
+++ b/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/Badge.kt
@@ -33,7 +33,7 @@ open class Badge @JvmOverloads constructor(
     TextDrawable.Delegate,
     Shapeable {
 
-    private val _badgeDrawable: BadgeDrawable = BadgeDrawable(
+    protected open var badgeDrawable: BadgeDrawable = BadgeDrawable(
         context = context,
         attrs = attrs,
         defStyleAttr = defStyleAttr,
@@ -49,7 +49,7 @@ open class Badge @JvmOverloads constructor(
      * @see Shapeable.shape
      */
     override val shape: ShapeModel?
-        get() = _badgeDrawable.shape
+        get() = badgeDrawable.shape
 
     /**
      * Состояние внешнего вида компонента [Badge]
@@ -67,18 +67,18 @@ open class Badge @JvmOverloads constructor(
      * Текст
      */
     open var text: CharSequence?
-        get() = _badgeDrawable.text
+        get() = badgeDrawable.text
         set(value) {
-            _badgeDrawable.text = value ?: ""
+            badgeDrawable.text = value ?: ""
         }
 
     /**
      * [Drawable] в начале компонента
      */
     open var drawableStart: Drawable?
-        get() = _badgeDrawable.drawableStart
+        get() = badgeDrawable.drawableStart
         set(value) {
-            _badgeDrawable.drawableStart = value
+            badgeDrawable.drawableStart = value
             refreshDrawableState()
         }
 
@@ -86,9 +86,9 @@ open class Badge @JvmOverloads constructor(
      * [Drawable] в конце компонента
      */
     open var drawableEnd: Drawable?
-        get() = _badgeDrawable.drawableEnd
+        get() = badgeDrawable.drawableEnd
         set(value) {
-            _badgeDrawable.drawableEnd = value
+            badgeDrawable.drawableEnd = value
             refreshDrawableState()
         }
 
@@ -97,7 +97,7 @@ open class Badge @JvmOverloads constructor(
      * @param colors цвета текста
      */
     open fun setTextColor(colors: ColorStateList?) {
-        _badgeDrawable.setTextColor(colors)
+        badgeDrawable.setTextColor(colors)
     }
 
     /**
@@ -105,7 +105,7 @@ open class Badge @JvmOverloads constructor(
      * @param appearanceId идентификатор стиля текста
      */
     open fun setTextAppearance(@StyleRes appearanceId: Int) {
-        _badgeDrawable.setTextAppearance(context, appearanceId)
+        badgeDrawable.setTextAppearance(context, appearanceId)
     }
 
     /**
@@ -113,7 +113,7 @@ open class Badge @JvmOverloads constructor(
      * @param drawableRes идентификатор ресурса [Drawable]
      */
     fun setDrawableStartRes(@DrawableRes drawableRes: Int) {
-        _badgeDrawable.setDrawableStartRes(context, drawableRes)
+        badgeDrawable.setDrawableStartRes(context, drawableRes)
     }
 
     /**
@@ -121,7 +121,7 @@ open class Badge @JvmOverloads constructor(
      * @param drawableRes идентификатор ресурса [Drawable]
      */
     fun setDrawableEndRes(@DrawableRes drawableRes: Int) {
-        _badgeDrawable.setDrawableEndRes(context, drawableRes)
+        badgeDrawable.setDrawableEndRes(context, drawableRes)
     }
 
     /**
@@ -129,7 +129,7 @@ open class Badge @JvmOverloads constructor(
      * @param colors цвета [Drawable] в начале
      */
     open fun setDrawableStartColors(colors: ColorStateList?) {
-        _badgeDrawable.setDrawableStartTint(colors)
+        badgeDrawable.setDrawableStartTint(colors)
         refreshDrawableState()
     }
 
@@ -146,7 +146,7 @@ open class Badge @JvmOverloads constructor(
      * @param colors цвета [Drawable] в конце
      */
     open fun setDrawableEndColors(colors: ColorStateList?) {
-        _badgeDrawable.setDrawableEndTint(colors)
+        badgeDrawable.setDrawableEndTint(colors)
         refreshDrawableState()
     }
 
@@ -160,15 +160,15 @@ open class Badge @JvmOverloads constructor(
 
     override fun setPadding(left: Int, top: Int, right: Int, bottom: Int) {
         super.setPadding(left, top, right, bottom)
-        _badgeDrawable.setPaddings(left, top, right, bottom)
+        badgeDrawable.setPaddings(left, top, right, bottom)
     }
 
     override fun setPaddingRelative(start: Int, top: Int, end: Int, bottom: Int) {
         super.setPaddingRelative(start, top, end, bottom)
         if (layoutDirection == LAYOUT_DIRECTION_RTL) {
-            _badgeDrawable.setPaddings(end, top, start, bottom)
+            badgeDrawable.setPaddings(end, top, start, bottom)
         } else {
-            _badgeDrawable.setPaddings(start, top, end, bottom)
+            badgeDrawable.setPaddings(start, top, end, bottom)
         }
     }
 
@@ -180,8 +180,8 @@ open class Badge @JvmOverloads constructor(
         val specWidth = MeasureSpec.getSize(widthMeasureSpec)
         val specHeight = MeasureSpec.getSize(heightMeasureSpec)
 
-        val intrinsicWidth = _badgeDrawable.intrinsicWidth
-        val intrinsicHeight = _badgeDrawable.intrinsicHeight
+        val intrinsicWidth = badgeDrawable.intrinsicWidth
+        val intrinsicHeight = badgeDrawable.intrinsicHeight
 
         val width = when (widthMode) {
             MeasureSpec.AT_MOST -> minOf(specWidth, maxOf(minimumWidth, intrinsicWidth))
@@ -195,21 +195,21 @@ open class Badge @JvmOverloads constructor(
             else -> maxOf(minimumHeight, intrinsicHeight)
         }
         setMeasuredDimension(width, height)
-        _badgeDrawable.setBounds(0, 0, measuredWidth, measuredHeight)
+        badgeDrawable.setBounds(0, 0, measuredWidth, measuredHeight)
     }
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        _badgeDrawable.draw(canvas)
+        badgeDrawable.draw(canvas)
     }
 
     override fun verifyDrawable(who: Drawable): Boolean {
-        return super.verifyDrawable(who) || who == _badgeDrawable
+        return super.verifyDrawable(who) || who == badgeDrawable
     }
 
     override fun drawableStateChanged() {
         super.drawableStateChanged()
-        _badgeDrawable.state = drawableState
+        badgeDrawable.state = drawableState
     }
 
     override fun onCreateDrawableState(extraSpace: Int): IntArray {

--- a/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/IconBadge.kt
+++ b/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/IconBadge.kt
@@ -2,6 +2,8 @@ package com.sdds.uikit
 
 import android.content.Context
 import android.util.AttributeSet
+import com.sdds.uikit.drawable.BadgeDrawable
+import com.sdds.uikit.drawable.IconBadgeDrawable
 
 /**
  * Компонент "Badge с иконкой".
@@ -16,6 +18,13 @@ open class IconBadge @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.sd_iconBadgeStyle,
     defStyleRes: Int = R.style.Sdds_Components_Badge,
 ) : Badge(context, attrs, defStyleAttr, defStyleRes) {
+
+    override var badgeDrawable: BadgeDrawable =
+        IconBadgeDrawable(context, attrs, defStyleAttr, defStyleRes).apply {
+            callback = this@IconBadge
+            setDelegate(this@IconBadge)
+            setPaddings(paddingStart, paddingTop, paddingEnd, paddingBottom)
+        }
 
     final override var text: CharSequence?
         get() = null

--- a/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/drawable/BadgeDrawable.kt
+++ b/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/drawable/BadgeDrawable.kt
@@ -12,7 +12,7 @@ import com.sdds.uikit.R
  * @param attrs аттрибуты
  * @param defStyleAttr аттрибут стиля по умолчанию
  */
-class BadgeDrawable(
+open class BadgeDrawable(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.sd_badgeStyle,

--- a/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/drawable/IconBadgeDrawable.kt
+++ b/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/drawable/IconBadgeDrawable.kt
@@ -1,0 +1,24 @@
+package com.sdds.uikit.drawable
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import com.sdds.uikit.R
+
+/**
+ * [Drawable] рисующий компонент IconBadge.
+ * @param context контекст
+ * @param attrs аттрибуты
+ * @param defStyleAttr аттрибут стиля по умолчанию
+ */
+open class IconBadgeDrawable(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.sd_iconBadgeStyle,
+    defStyleRes: Int = R.style.Sdds_Components_IconBadge,
+) : BadgeDrawable(context, attrs, defStyleAttr, defStyleRes) {
+
+    override var text: CharSequence
+        get() = ""
+        set(_) {}
+}

--- a/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/drawable/TextDrawable.kt
+++ b/sdds-core/uikit/src/main/kotlin/com/sdds/uikit/drawable/TextDrawable.kt
@@ -97,7 +97,7 @@ open class TextDrawable(
     /**
      * Текст
      */
-    var text: CharSequence
+    open var text: CharSequence
         get() = _text
         set(value) {
             if (_text != value) {


### PR DESCRIPTION
Удалена возможность задать текст в IconBadge через xml
<img width="1093" height="452" alt="Снимок экрана 2025-07-28 в 19 13 21" src="https://github.com/user-attachments/assets/e5e8e6a1-a167-4bd8-8143-2109b385eb36" />
