### PR TITLE
fix(sdds-acore/uikit-compose): BaseCell now occupies width with null …

### DIFF
--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/cell/BaseCell.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/cell/BaseCell.kt
@@ -51,15 +51,13 @@ internal fun BaseCell(
                 startContent()
                 Spacer(Modifier.width(style.dimensions.contentPaddingStart))
             }
-            centerContent?.let {
-                Column(
-                    modifier = Modifier
-                        .weight(1f, fill = false)
-                        .fillMaxWidth(),
-                    horizontalAlignment = Alignment.Start,
-                ) {
-                    centerContent()
-                }
+            Column(
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.Start,
+            ) {
+                centerContent?.invoke(this)
             }
             endContent?.let {
                 Spacer(Modifier.width(style.dimensions.contentPaddingEnd))


### PR DESCRIPTION
## sdds-uikit-compose

### Cell
- Исправлено некорректное поведение в Cell, при котором если centerContent == null, то Cell не занимал всю доступную ширину, и endContent "прилипал" к startContent.

### What/why changed
Исправлено некорректное поведение в Cell, при котором если centerContent == null, то Cell не занимал всю доступную ширину, и endContent "прилипал" к startContent. Корректное поведение - даже если centerContent == null, центральная часть cell должна растягиваться на всю ширину


