### PR TITLE
PLASMA-5761: fix(sdds-acore/uikit-compose): apply focus selector modifiers in right way

### DIFF
--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/fs/FocusSelectorSettings.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/fs/FocusSelectorSettings.kt
@@ -129,8 +129,8 @@ fun Modifier.focusSelector(
 ): Modifier {
     val scale = 1f + settings.scale.scaleFactor
     return this
-        .then(settings.scale.run { applyScaleToModifier(isFocused) })
-        .then(settings.border.run { applyBorderToModifier(scale, shape, isFocused) })
+        .then(settings.scale.run { Modifier.applyScaleToModifier(isFocused) })
+        .then(settings.border.run { Modifier.applyBorderToModifier(scale, shape, isFocused) })
 }
 
 @Immutable


### PR DESCRIPTION
## sdds-uikit-compose

### FocusSelector

-   Исправлено некорректное поведение модификатора focusSelector().

### What/why changed
При применении focusSelector() он некорректно смешивал всю цепочку модификаторов до него с такой же цепочкой плюс модифкатор скейла / бордера. Это приводило к двойному/тройному применению всей цепочки, и если в ней были паддинги, они увеличивались в 2-3 раза.
