### PR TITLE
PLASMA-5905: feat(sdds-alibs/plasma-star-ds): Add extensions for scaled dp and sp.

### DIFF
--- a/tokens/plasma-stards-compose/src/main/kotlin/com/sdkit/star/designsystem/DimensionUtils.kt
+++ b/tokens/plasma-stards-compose/src/main/kotlin/com/sdkit/star/designsystem/DimensionUtils.kt
@@ -1,0 +1,65 @@
+package com.sdkit.star.designsystem
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import com.sdkit.star.designsystem.compose.R
+
+/**
+ * Extension property для преобразования целого числа в единицу измерения [Dp] с учетом стандартного базового размера из ресурсов.
+ *
+ * Используется для масштабирования размеров интерфейса в соответствии с дизайн-системой, где базовая размерность задается через ресурс [R.dimen.sdkit_cmp_standard_dimen].
+ * Например, 2.dp вернет значение, равное удвоенному базовому размеру.
+ *
+ * @receiver Int множитель базового размера.
+ * @return [Dp] результат умножения базового размера на [Int].
+ */
+val Int.dp: Dp
+    @Composable
+    @ReadOnlyComposable
+    get() = dimensionResource(R.dimen.sdkit_cmp_standard_dp) * this
+
+/**
+ * Extension property для преобразования целого числа в текстовую единицу измерения [TextUnit] (sp) с учетом стандартного базового размера из ресурсов.
+ *
+ * Используется для масштабирования размеров шрифтов в соответствии с дизайн-системой, где базовая размерность задается через ресурс [R.dimen.sdkit_cmp_standard_dimen].
+ * Например, 2.sp вернет значение, равное удвоенному базовому размеру в sp.
+ *
+ * @receiver Int множитель базового размера.
+ * @return [TextUnit] результат умножения базового размера на [Int] в sp.
+ */
+val Int.sp: TextUnit
+    @Composable
+    @ReadOnlyComposable
+    get() = (dimensionResource(R.dimen.sdkit_cmp_standard_sp).value * this).sp
+
+/**
+ * Extension property для преобразования числа с плавающей точкой в единицу измерения [Dp] с учетом стандартного базового размера из ресурсов.
+ *
+ * Используется для более точного масштабирования размеров интерфейса в соответствии с дизайн-системой, где базовая размерность задается через ресурс [R.dimen.sdkit_cmp_standard_dimen].
+ * Например, 1.5f.dp вернет значение, равное 1.5 * базовый размер.
+ *
+ * @receiver Float множитель базового размера.
+ * @return [Dp] результат умножения базового размера на [Float].
+ */
+val Float.dp: Dp
+    @Composable
+    @ReadOnlyComposable
+    get() = dimensionResource(R.dimen.sdkit_cmp_standard_dp) * this
+
+/**
+ * Extension property для преобразования числа с плавающей точкой в текстовую единицу измерения [TextUnit] (sp) с учетом стандартного базового размера из ресурсов.
+ *
+ * Используется для более точного масштабирования размеров шрифтов в соответствии с дизайн-системой, где базовая размерность задается через ресурс [R.dimen.sdkit_cmp_standard_dimen].
+ * Например, 1.5f.sp вернет значение, равное 1.5 * базовый размер в sp.
+ *
+ * @receiver Float множитель базового размера.
+ * @return [TextUnit] результат умножения базового размера на [Float] в sp.
+ */
+val Float.sp: TextUnit
+    @Composable
+    @ReadOnlyComposable
+    get() = (dimensionResource(R.dimen.sdkit_cmp_standard_sp).value * this).sp

--- a/tokens/plasma-stards-compose/src/main/res/values/dimens.xml
+++ b/tokens/plasma-stards-compose/src/main/res/values/dimens.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    
+    <dimen name="sdkit_cmp_standard_dp">2dp</dimen>
+    <dimen name="sdkit_cmp_standard_sp">2sp</dimen>
 
     <dimen name="sdkit_cmp_avatar_group_s_item_offset">32dp</dimen> <!-- 16dp -->
     <dimen name="sdkit_cmp_avatar_group_s_item_spacing">4dp</dimen> <!-- 2dp -->


### PR DESCRIPTION
## plasma-star-ds-compose
### Dimensions 
- Добавлены extension свойства .dp и .sp. Теперь можно указывать dimensions в коде, не заботясь о ресурсах для альтернативных размеров экранов - расчет происходит автоматически.

### What/why changed
- Добавил эталонные dimensions для расчета dp и sp в коде. Плагин для dimensions подготовит альтернативы для эталонных dimensions и в коде будут использованы корректные размеры. 