### PR TITLE
PLASMA-7134: chore: update kotlin version

### DIFF
--- a/build-system/build.gradle.kts
+++ b/build-system/build.gradle.kts
@@ -16,7 +16,6 @@ buildscript {
         classpath(libs.base.gradle.kotlin)
         classpath(libs.base.gradle.nexusPublish)
         classpath(libs.base.dokka.graddle)
-        classpath(libs.base.dokka.analysis)
         classpath(libs.base.kotlin.ksp)
         classpath(libs.base.gradle.compose)
     }

--- a/build-system/build.gradle.kts
+++ b/build-system/build.gradle.kts
@@ -16,6 +16,7 @@ buildscript {
         classpath(libs.base.gradle.kotlin)
         classpath(libs.base.gradle.nexusPublish)
         classpath(libs.base.dokka.graddle)
+        classpath(libs.base.dokka.analysis)
         classpath(libs.base.kotlin.ksp)
         classpath(libs.base.gradle.compose)
     }

--- a/build-system/build.gradle.kts
+++ b/build-system/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
         classpath(libs.base.gradle.kotlin)
         classpath(libs.base.gradle.nexusPublish)
         classpath(libs.base.dokka.graddle)
-        classpath(libs.base.dokka.analysis)
+//        classpath(libs.base.dokka.analysis)
         classpath(libs.base.kotlin.ksp)
         classpath(libs.base.gradle.compose)
     }

--- a/build-system/conventions/build.gradle.kts
+++ b/build-system/conventions/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     implementation(libs.base.dokka.graddle)
     implementation(libs.base.dokka)
     implementation(libs.base.kotlin.serialization.json)
-    implementation(libs.base.kotlin.compiler.embeddable)
     implementation(libs.base.kotlin.compose.compiler)
     implementation("org.commonmark:commonmark:0.21.0")
     implementation(libs.base.gradle.compose)

--- a/build-system/conventions/build.gradle.kts
+++ b/build-system/conventions/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     }
     implementation(libs.base.gradle.cacheFix)
     implementation(libs.base.gradle.kotlin)
-    implementation(libs.base.gradle.paparazzi)
     implementation(libs.base.gradle.detekt)
     implementation(libs.base.gradle.spotless)
     implementation(libs.base.gradle.nexusPublish)
@@ -21,6 +20,7 @@ dependencies {
     implementation(libs.base.dokka)
     implementation(libs.base.kotlin.serialization.json)
     implementation(libs.base.kotlin.compiler.embeddable)
+    implementation(libs.base.kotlin.compose.compiler)
     implementation("org.commonmark:commonmark:0.21.0")
     implementation(libs.base.gradle.compose)
     implementation(libs.base.gradle.mavenpublish)

--- a/build-system/conventions/build.gradle.kts
+++ b/build-system/conventions/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(libs.base.dokka.graddle)
     implementation(libs.base.dokka)
     implementation(libs.base.kotlin.serialization.json)
-    implementation(libs.base.kotlin.compiler.embeddable)
+    compileOnly(libs.base.kotlin.compiler.embeddable)
     implementation(libs.base.kotlin.compose.compiler)
     implementation("org.commonmark:commonmark:0.21.0")
     implementation(libs.base.gradle.compose)

--- a/build-system/conventions/build.gradle.kts
+++ b/build-system/conventions/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.base.dokka.graddle)
     implementation(libs.base.dokka)
     implementation(libs.base.kotlin.serialization.json)
+    implementation(libs.base.kotlin.compiler.embeddable)
     implementation(libs.base.kotlin.compose.compiler)
     implementation("org.commonmark:commonmark:0.21.0")
     implementation(libs.base.gradle.compose)

--- a/build-system/conventions/src/main/kotlin/convention.cmp-app.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.cmp-app.gradle.kts
@@ -1,9 +1,11 @@
 import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import utils.versionInfo
 import utils.withVersionCatalogs
 
 plugins {
     id("com.android.application")
+    id("org.jetbrains.kotlin.plugin.compose")
     kotlin("multiplatform")
     id("org.jetbrains.compose")
     id("convention.detekt")
@@ -11,11 +13,11 @@ plugins {
 }
 
 kotlin {
-    android {
+    androidTarget {
         withVersionCatalogs {
             compilations.all {
-                kotlinOptions {
-                    jvmTarget = versions.global.jvmTarget.get()
+                this@androidTarget.compilerOptions {
+                    jvmTarget.set(JvmTarget.fromTarget(versions.global.jvmTarget.get()))
                 }
             }
         }
@@ -44,12 +46,6 @@ android {
             versionName = vInfo.name
             versionNameSuffix = vInfo.nameSuffix
 
-        }
-    }
-
-    withVersionCatalogs {
-        composeOptions {
-            kotlinCompilerExtensionVersion = versions.androidX.compose.compiler.get()
         }
     }
 

--- a/build-system/conventions/src/main/kotlin/convention.cmp-lib.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.cmp-lib.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library")
     id("org.gradle.android.cache-fix")
     id("convention.kotlin-java-version-sync")
+    id("org.jetbrains.kotlin.plugin.compose")
     kotlin("multiplatform")
     id("org.jetbrains.compose")
     id("convention.detekt")
@@ -22,10 +23,6 @@ android {
 
         buildFeatures {
             compose = true
-        }
-
-        composeOptions {
-            kotlinCompilerExtensionVersion = versions.androidX.compose.compiler.get()
         }
     }
 

--- a/build-system/conventions/src/main/kotlin/convention.compose-multiplatform.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.compose-multiplatform.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.kotlin.dsl.kotlin
 
 plugins {
+    id("org.jetbrains.kotlin.plugin.compose")
     kotlin("multiplatform")
     id("org.jetbrains.compose")
 }

--- a/build-system/conventions/src/main/kotlin/convention.compose.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.compose.gradle.kts
@@ -3,6 +3,10 @@ import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.LibraryExtension
 import utils.withVersionCatalogs
 
+plugins {
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
 val extension = app() ?: lib() ?: throwApplyException()
 extension.configureCompose()
 
@@ -20,7 +24,6 @@ fun throwApplyException(): Nothing =
 
 fun CommonExtension<*, *, *, *, *, *>.configureCompose() = withVersionCatalogs {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = versions.androidX.compose.compiler.get()
 
     dependencies {
         // Эта зависимость в обязательном порядке нужна компилятору Compose по этому есть смысл

--- a/build-system/conventions/src/main/kotlin/convention.core-fixtures.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.core-fixtures.gradle.kts
@@ -2,17 +2,30 @@ import com.android.build.gradle.LibraryExtension
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import tasks.docs.ExtractCodeSnippetsTask
-import org.gradle.api.attributes.Attribute
 import utils.baseDetektConfigDirPath
 import utils.baseDetektConfigPath
 import utils.isAndroidLib
+import utils.withVersionCatalogs
 
 
 val docsDirPath = "docs"
 
+val kotlinCompilerDependencies = configurations.create("kotlinCompilerDependencies")
+
+dependencies {
+    withVersionCatalogs {
+        add(kotlinCompilerDependencies.name, base.kotlin.compiler.embeddable)
+    }
+}
+
+val kotlinCompilerClassPath = configurations.create("kotlinCompilerClassPath") {
+    extendsFrom(kotlinCompilerDependencies)
+}
+
 tasks.register<ExtractCodeSnippetsTask>("collectCodeSnippets") {
     group = "documentation"
     description = "Извлекает код внутри codeSnippet/composableCodeSnippet из функций @DocSample"
+    kotlinCompiler.from(kotlinCompilerClassPath)
     if (isAndroidLib()) {
         val namespace = project.extensions.getByType(LibraryExtension::class.java).namespace.orEmpty()
         xmlNamespace.set(namespace)

--- a/build-system/conventions/src/main/kotlin/convention.documentation.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.documentation.gradle.kts
@@ -2,15 +2,25 @@ import com.android.build.gradle.LibraryExtension
 import extensions.docs.DocusaurusExtension
 import extensions.docs.FixturesExtension
 import io.gitlab.arturbosch.detekt.Detekt
-import tasks.docs.ExtractCodeSnippetsTask
 import tasks.docs.UnzipCodeSnippetsTask
 import org.gradle.api.attributes.Attribute
+import tasks.docs.ExtractCodeSnippetsTask
 import utils.isAndroidLib
 
 plugins {
     id("convention.android-lib")
     id("convention.docusaurus")
     id("com.google.devtools.ksp")
+}
+
+val kotlinCompilerDependencies = configurations.create("kotlinCompilerDependencies")
+
+dependencies {
+    add(kotlinCompilerDependencies.name, "org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.10")
+}
+
+val kotlinCompilerClassPath = configurations.create("kotlinCompilerClassPath") {
+    extendsFrom(kotlinCompilerDependencies)
 }
 
 val docsVariantAttr: Attribute<String> = Attribute.of("com.sdds.docs.variant", String::class.java)
@@ -30,6 +40,9 @@ extensions.configure<DocusaurusExtension>("docusaurus") {
 val collectSnippets = tasks.register<ExtractCodeSnippetsTask>("collectCodeSnippets") {
     group = "documentation"
     description = "Извлекает код внутри codeSnippet/composableCodeSnippet из функций @DocSample"
+
+    kotlinCompiler.from(kotlinCompilerClassPath)
+
     if (isAndroidLib()) {
         val namespace = project.extensions.getByType(LibraryExtension::class.java).namespace.orEmpty()
         xmlNamespace.set(namespace)

--- a/build-system/conventions/src/main/kotlin/convention.kotlin-java-version-sync.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.kotlin-java-version-sync.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import utils.withVersionCatalogs
@@ -6,16 +7,15 @@ description = "Синхронизация версий Java для Kotlin и Jav
 
 withVersionCatalogs {
     tasks.withType<KaptGenerateStubs>().configureEach {
-        kotlinOptions {
-            jvmTarget = versions.global.jvmTarget.get()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(versions.global.jvmTarget.get()))
         }
     }
 
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = versions.global.jvmTarget.get()
-            freeCompilerArgs = freeCompilerArgs +
-                "-opt-in=kotlin.RequiresOptIn"
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(versions.global.jvmTarget.get()))
+            freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
         }
     }
     tasks.withType<JavaCompile>().configureEach {

--- a/build-system/conventions/src/main/kotlin/convention.maven-publish.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.maven-publish.gradle.kts
@@ -1,6 +1,4 @@
 import com.vanniktech.maven.publish.SonatypeHost
-import gradle.kotlin.dsl.accessors._8edd1b0c1852f0ac869e9c414c462ba9.mavenPublishing
-import gradle.kotlin.dsl.accessors._8edd1b0c1852f0ac869e9c414c462ba9.publishing
 import utils.findPropertyOrDefault
 import utils.versionInfo
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository

--- a/build-system/conventions/src/main/kotlin/convention.sandbox-app.gradle.kts
+++ b/build-system/conventions/src/main/kotlin/convention.sandbox-app.gradle.kts
@@ -56,17 +56,6 @@ android {
     tasks.withType<Test> {
         maxHeapSize = "4096m"
     }
-    kotlinOptions {
-        //comment following lines (freeCompilerArgs) to disable compose-metrics
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
-        )
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
-        )
-    }
 
     signingConfigs {
         create("release") {
@@ -88,6 +77,19 @@ android {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            listOf(
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.buildDir.absolutePath}/compose_metrics",
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.buildDir.absolutePath}/compose_metrics"
+            )
+        )
     }
 }
 

--- a/build-system/conventions/src/main/kotlin/tasks/docs/ActionUsingKotlinCompiler.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/ActionUsingKotlinCompiler.kt
@@ -1,0 +1,90 @@
+package tasks.docs
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.google.gson.GsonBuilder
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.slf4j.LoggerFactory
+import java.io.File
+
+abstract class ActionUsingKotlinCompiler : WorkAction<ActionUsingKotlinCompiler.Params> {
+
+    interface Params : WorkParameters {
+        val kotlinSources: ConfigurableFileCollection
+        val xmlSources: ConfigurableFileCollection
+        val outputKotlinDir: DirectoryProperty
+        val outputXmlDir: DirectoryProperty
+        val outputMeta: RegularFileProperty
+        val namespace: Property<String>
+        val projectDir: DirectoryProperty
+    }
+
+    private val logger = LoggerFactory.getLogger(ActionUsingKotlinCompiler::class.java)
+
+    override fun execute() {
+        logger.info("Kotlin compiler version: ${KotlinCompilerVersion.getVersion()}")
+
+        val outKotlinDir = parameters.outputKotlinDir.get().asFile
+        outKotlinDir.mkdirs()
+
+        val outXmlDir = parameters.outputXmlDir.get().asFile
+        outXmlDir.mkdirs()
+
+        val kotlinFiles = parameters.kotlinSources.files.toList()
+        val xmlFiles = parameters.xmlSources.files.toList()
+        val meta = mutableListOf<SampleMeta>()
+
+        val disposable = Disposer.newDisposable("sdds-docs-psi")
+        try {
+            val env = KotlinCoreEnvironment.createForProduction(
+                disposable,
+                CompilerConfiguration(),
+                EnvironmentConfigFiles.JVM_CONFIG_FILES
+            )
+            val projectDir = parameters.projectDir.get().asFile
+
+            val psiFactory = KtPsiFactory(env.project, markGenerated = false)
+
+            val kotlinDelegate = KotlinSnippetExtractorDelegate(
+                psiFactory = psiFactory,
+                snippetsDir = outKotlinDir,
+                projectDir = projectDir,
+            )
+
+            kotlinFiles.forEach { file ->
+                meta += kotlinDelegate.extractFromFile(file)
+            }
+
+            val xmlDelegate = XmlSnippetExtractorDelegate(
+                snippetsDir = outXmlDir,
+                projectDir = projectDir,
+                namespace = parameters.namespace.get()
+            )
+
+            xmlFiles.forEach { file ->
+                meta += xmlDelegate.extractFromFile(file)
+            }
+
+            val metaFile = parameters.outputMeta.asFile.get()
+            val gson = GsonBuilder().setPrettyPrinting().create()
+            metaFile.writeText(gson.toJson(meta))
+            logger.info("Written docs meta: ${relativePath(projectDir, metaFile)} (samples=${meta.size})")
+        } finally {
+            Disposer.dispose(disposable)
+        }
+
+    }
+}
+
+internal fun relativePath(dir: File, target: File): String {
+    return dir.toURI().relativize(target.toURI()).path
+}

--- a/build-system/conventions/src/main/kotlin/tasks/docs/ExtractCodeSnippetsTask.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/ExtractCodeSnippetsTask.kt
@@ -5,6 +5,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
@@ -12,12 +13,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.com.google.gson.GsonBuilder
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.psi.KtPsiFactory
 
 abstract class ExtractCodeSnippetsTask : DefaultTask() {
 
@@ -30,7 +25,6 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
     @get:OutputFile
     abstract val outputMeta: RegularFileProperty
 
-
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val kotlinSources: ConfigurableFileCollection
@@ -40,7 +34,7 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
     abstract val xmlSources: ConfigurableFileCollection
 
     @get:Input
-    abstract val xmlNamespace: org.gradle.api.provider.Property<String>
+    abstract val xmlNamespace: Property<String>
 
     init {
         kotlinSources.from(kotlinSourceTrees())
@@ -50,81 +44,72 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        val outKotlinDir = outputKotlinDir.get().asFile
-        outKotlinDir.mkdirs()
+        val outKotlinDir = outputKotlinDir.get().asFile.also { it.mkdirs() }
+        val outXmlDir    = outputXmlDir.get().asFile.also    { it.mkdirs() }
 
-        val outXmlDir = outputXmlDir.get().asFile
-        outXmlDir.mkdirs()
-
-        val kotlinFiles = kotlinSources.files.toList()
-        val xmlFiles = xmlSources.files.toList()
         val meta = mutableListOf<SampleMeta>()
 
-        val disposable = Disposer.newDisposable("sdds-docs-psi")
-        try {
-            val env = KotlinCoreEnvironment.createForProduction(
-                disposable,
-                CompilerConfiguration(),
-                EnvironmentConfigFiles.JVM_CONFIG_FILES
-            )
+        val kotlinDelegate = KotlinSnippetExtractorDelegate(
+            snippetsDir = outKotlinDir,
+            project     = project,
+        )
+        kotlinSources.files.forEach { meta += kotlinDelegate.extractFromFile(it) }
 
-            val psiFactory = KtPsiFactory(env.project, markGenerated = false)
+        val xmlDelegate = XmlSnippetExtractorDelegate(
+            snippetsDir = outXmlDir,
+            project     = project,
+            namespace   = xmlNamespace.get(),
+        )
+        xmlSources.files.forEach { meta += xmlDelegate.extractFromFile(it) }
 
-            val kotlinDelegate = KotlinSnippetExtractorDelegate(
-                psiFactory = psiFactory,
-                snippetsDir = outKotlinDir,
-                project = project
-            )
-
-            kotlinFiles.forEach { file ->
-                meta += kotlinDelegate.extractFromFile(file)
-            }
-
-            val xmlDelegate = XmlSnippetExtractorDelegate(
-                snippetsDir = outXmlDir,
-                project = project,
-                namespace = xmlNamespace.get()
-            )
-
-            xmlFiles.forEach { file ->
-                meta += xmlDelegate.extractFromFile(file)
-            }
-
-            val metaFile = outputMeta.asFile.get()
-            val gson = GsonBuilder().setPrettyPrinting().create()
-            metaFile.writeText(gson.toJson(meta))
-            logger.lifecycle("Written docs meta: ${project.relativePath(metaFile)} (samples=${meta.size})")
-        } finally {
-            Disposer.dispose(disposable)
-        }
+        val metaFile = outputMeta.asFile.get()
+        metaFile.writeText(serializeMetaToJson(meta))
+        logger.lifecycle("Written docs meta: ${project.relativePath(metaFile)} (samples=${meta.size})")
     }
 
+    // ── JSON ──────────────────────────────────────────────────────────────────
+
+    private fun serializeMetaToJson(meta: List<SampleMeta>): String = buildString {
+        appendLine("[")
+        meta.forEachIndexed { i, m ->
+            appendLine("  {")
+            appendLine("""    "id": ${m.id.toJsonString()},""")
+            appendLine("""    "kind": ${m.kind.toJsonString()},""")
+            appendLine("""    "fqName": ${m.fqName.toJsonString()},""")
+            appendLine("""    "file": ${m.file.toJsonString()},""")
+            appendLine("""    "snippetPath": ${m.snippetPath.toJsonString()},""")
+            appendLine("""    "snippetStartOffset": ${m.snippetStartOffset},""")
+            append("""    "snippetEndOffset": ${m.snippetEndOffset}""")
+            appendLine()
+            append("  }")
+            if (i < meta.lastIndex) append(",")
+            appendLine()
+        }
+        append("]")
+    }
+
+    private fun String.toJsonString(): String {
+        val escaped = replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        return "\"$escaped\""
+    }
 
     private fun kotlinSourceTrees(): FileCollection {
-        val roots = listOf(
-            project.file("src/main/kotlin"),
-            project.file("src/main/java"),
-            project.file("src")
-        ).filter { it.exists() }
-
+        val roots = listOf("src/main/kotlin", "src/main/java", "src")
+            .map(project::file).filter { it.exists() }
         return project.files(roots.map { root ->
-            project.fileTree(root) {
-                include("**/*.kt")
-            }
+            project.fileTree(root) { include("**/*.kt") }
         })
     }
 
     private fun xmlSourceTrees(): FileCollection {
-        val roots = listOf(
-            project.file("src/main/res"),
-            project.file("src/main/resources"),
-            project.file("src")
-        ).filter { it.exists() }
-
+        val roots = listOf("src/main/res", "src/main/resources", "src")
+            .map(project::file).filter { it.exists() }
         return project.files(roots.map { root ->
-            project.fileTree(root) {
-                include("**/*.xml")
-            }
+            project.fileTree(root) { include("**/*.xml") }
         })
     }
 }

--- a/build-system/conventions/src/main/kotlin/tasks/docs/ExtractCodeSnippetsTask.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/ExtractCodeSnippetsTask.kt
@@ -5,7 +5,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
@@ -13,6 +12,12 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.google.gson.GsonBuilder
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.psi.KtPsiFactory
 
 abstract class ExtractCodeSnippetsTask : DefaultTask() {
 
@@ -25,6 +30,7 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
     @get:OutputFile
     abstract val outputMeta: RegularFileProperty
 
+
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val kotlinSources: ConfigurableFileCollection
@@ -34,7 +40,7 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
     abstract val xmlSources: ConfigurableFileCollection
 
     @get:Input
-    abstract val xmlNamespace: Property<String>
+    abstract val xmlNamespace: org.gradle.api.provider.Property<String>
 
     init {
         kotlinSources.from(kotlinSourceTrees())
@@ -44,72 +50,81 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        val outKotlinDir = outputKotlinDir.get().asFile.also { it.mkdirs() }
-        val outXmlDir    = outputXmlDir.get().asFile.also    { it.mkdirs() }
+        val outKotlinDir = outputKotlinDir.get().asFile
+        outKotlinDir.mkdirs()
 
+        val outXmlDir = outputXmlDir.get().asFile
+        outXmlDir.mkdirs()
+
+        val kotlinFiles = kotlinSources.files.toList()
+        val xmlFiles = xmlSources.files.toList()
         val meta = mutableListOf<SampleMeta>()
 
-        val kotlinDelegate = KotlinSnippetExtractorDelegate(
-            snippetsDir = outKotlinDir,
-            project     = project,
-        )
-        kotlinSources.files.forEach { meta += kotlinDelegate.extractFromFile(it) }
+        val disposable = Disposer.newDisposable("sdds-docs-psi")
+        try {
+            val env = KotlinCoreEnvironment.createForProduction(
+                disposable,
+                CompilerConfiguration(),
+                EnvironmentConfigFiles.JVM_CONFIG_FILES
+            )
 
-        val xmlDelegate = XmlSnippetExtractorDelegate(
-            snippetsDir = outXmlDir,
-            project     = project,
-            namespace   = xmlNamespace.get(),
-        )
-        xmlSources.files.forEach { meta += xmlDelegate.extractFromFile(it) }
+            val psiFactory = KtPsiFactory(env.project, markGenerated = false)
 
-        val metaFile = outputMeta.asFile.get()
-        metaFile.writeText(serializeMetaToJson(meta))
-        logger.lifecycle("Written docs meta: ${project.relativePath(metaFile)} (samples=${meta.size})")
-    }
+            val kotlinDelegate = KotlinSnippetExtractorDelegate(
+                psiFactory = psiFactory,
+                snippetsDir = outKotlinDir,
+                project = project
+            )
 
-    // ── JSON ──────────────────────────────────────────────────────────────────
+            kotlinFiles.forEach { file ->
+                meta += kotlinDelegate.extractFromFile(file)
+            }
 
-    private fun serializeMetaToJson(meta: List<SampleMeta>): String = buildString {
-        appendLine("[")
-        meta.forEachIndexed { i, m ->
-            appendLine("  {")
-            appendLine("""    "id": ${m.id.toJsonString()},""")
-            appendLine("""    "kind": ${m.kind.toJsonString()},""")
-            appendLine("""    "fqName": ${m.fqName.toJsonString()},""")
-            appendLine("""    "file": ${m.file.toJsonString()},""")
-            appendLine("""    "snippetPath": ${m.snippetPath.toJsonString()},""")
-            appendLine("""    "snippetStartOffset": ${m.snippetStartOffset},""")
-            append("""    "snippetEndOffset": ${m.snippetEndOffset}""")
-            appendLine()
-            append("  }")
-            if (i < meta.lastIndex) append(",")
-            appendLine()
+            val xmlDelegate = XmlSnippetExtractorDelegate(
+                snippetsDir = outXmlDir,
+                project = project,
+                namespace = xmlNamespace.get()
+            )
+
+            xmlFiles.forEach { file ->
+                meta += xmlDelegate.extractFromFile(file)
+            }
+
+            val metaFile = outputMeta.asFile.get()
+            val gson = GsonBuilder().setPrettyPrinting().create()
+            metaFile.writeText(gson.toJson(meta))
+            logger.lifecycle("Written docs meta: ${project.relativePath(metaFile)} (samples=${meta.size})")
+        } finally {
+            Disposer.dispose(disposable)
         }
-        append("]")
     }
 
-    private fun String.toJsonString(): String {
-        val escaped = replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t")
-        return "\"$escaped\""
-    }
 
     private fun kotlinSourceTrees(): FileCollection {
-        val roots = listOf("src/main/kotlin", "src/main/java", "src")
-            .map(project::file).filter { it.exists() }
+        val roots = listOf(
+            project.file("src/main/kotlin"),
+            project.file("src/main/java"),
+            project.file("src")
+        ).filter { it.exists() }
+
         return project.files(roots.map { root ->
-            project.fileTree(root) { include("**/*.kt") }
+            project.fileTree(root) {
+                include("**/*.kt")
+            }
         })
     }
 
     private fun xmlSourceTrees(): FileCollection {
-        val roots = listOf("src/main/res", "src/main/resources", "src")
-            .map(project::file).filter { it.exists() }
+        val roots = listOf(
+            project.file("src/main/res"),
+            project.file("src/main/resources"),
+            project.file("src")
+        ).filter { it.exists() }
+
         return project.files(roots.map { root ->
-            project.fileTree(root) { include("**/*.xml") }
+            project.fileTree(root) {
+                include("**/*.xml")
+            }
         })
     }
 }

--- a/build-system/conventions/src/main/kotlin/tasks/docs/ExtractCodeSnippetsTask.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/ExtractCodeSnippetsTask.kt
@@ -5,6 +5,8 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
@@ -12,12 +14,8 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.com.google.gson.GsonBuilder
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
 
 abstract class ExtractCodeSnippetsTask : DefaultTask() {
 
@@ -30,7 +28,6 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
     @get:OutputFile
     abstract val outputMeta: RegularFileProperty
 
-
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val kotlinSources: ConfigurableFileCollection
@@ -39,8 +36,14 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val xmlSources: ConfigurableFileCollection
 
+    @get:Inject
+    abstract val executor: WorkerExecutor
+
+    @get:Classpath
+    abstract val kotlinCompiler: ConfigurableFileCollection
+
     @get:Input
-    abstract val xmlNamespace: org.gradle.api.provider.Property<String>
+    abstract val xmlNamespace: Property<String>
 
     init {
         kotlinSources.from(kotlinSourceTrees())
@@ -49,56 +52,20 @@ abstract class ExtractCodeSnippetsTask : DefaultTask() {
     }
 
     @TaskAction
-    fun run() {
-        val outKotlinDir = outputKotlinDir.get().asFile
-        outKotlinDir.mkdirs()
-
-        val outXmlDir = outputXmlDir.get().asFile
-        outXmlDir.mkdirs()
-
-        val kotlinFiles = kotlinSources.files.toList()
-        val xmlFiles = xmlSources.files.toList()
-        val meta = mutableListOf<SampleMeta>()
-
-        val disposable = Disposer.newDisposable("sdds-docs-psi")
-        try {
-            val env = KotlinCoreEnvironment.createForProduction(
-                disposable,
-                CompilerConfiguration(),
-                EnvironmentConfigFiles.JVM_CONFIG_FILES
-            )
-
-            val psiFactory = KtPsiFactory(env.project, markGenerated = false)
-
-            val kotlinDelegate = KotlinSnippetExtractorDelegate(
-                psiFactory = psiFactory,
-                snippetsDir = outKotlinDir,
-                project = project
-            )
-
-            kotlinFiles.forEach { file ->
-                meta += kotlinDelegate.extractFromFile(file)
-            }
-
-            val xmlDelegate = XmlSnippetExtractorDelegate(
-                snippetsDir = outXmlDir,
-                project = project,
-                namespace = xmlNamespace.get()
-            )
-
-            xmlFiles.forEach { file ->
-                meta += xmlDelegate.extractFromFile(file)
-            }
-
-            val metaFile = outputMeta.asFile.get()
-            val gson = GsonBuilder().setPrettyPrinting().create()
-            metaFile.writeText(gson.toJson(meta))
-            logger.lifecycle("Written docs meta: ${project.relativePath(metaFile)} (samples=${meta.size})")
-        } finally {
-            Disposer.dispose(disposable)
+    fun compile() {
+        val workQueue = executor.classLoaderIsolation {
+            classpath.from(kotlinCompiler)
+        }
+        workQueue.submit(ActionUsingKotlinCompiler::class.java) {
+            kotlinSources.from(this@ExtractCodeSnippetsTask.kotlinSources)
+            xmlSources.from(this@ExtractCodeSnippetsTask.xmlSources)
+            outputKotlinDir.set(this@ExtractCodeSnippetsTask.outputKotlinDir)
+            outputXmlDir.set(this@ExtractCodeSnippetsTask.outputXmlDir)
+            outputMeta.set(this@ExtractCodeSnippetsTask.outputMeta)
+            namespace.set(this@ExtractCodeSnippetsTask.xmlNamespace)
+            projectDir.set(project.layout.projectDirectory)
         }
     }
-
 
     private fun kotlinSourceTrees(): FileCollection {
         val roots = listOf(

--- a/build-system/conventions/src/main/kotlin/tasks/docs/KotlinSnippetExtractorDelegate.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/KotlinSnippetExtractorDelegate.kt
@@ -1,202 +1,229 @@
 package tasks.docs
 
 import org.gradle.api.Project
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import java.io.File
 
 internal class KotlinSnippetExtractorDelegate(
+    private val psiFactory: KtPsiFactory,
     private val snippetsDir: File,
     private val project: Project,
 ) {
-    // @DocSample("id")  or  @DocSample(id = "id")
-    private val docSampleRe = Regex(
-        """@DocSample\s*\(\s*(?:id\s*=\s*)?\"([^\"]+)\"\s*\)"""
-    )
-    private val snippetCallRe = Regex(
-        """(composableCodeSnippet|codeSnippet)\s*\{"""
-    )
-    private val packageRe = Regex("""^\s*package\s+([\w.]+)""", RegexOption.MULTILINE)
-    private val funRe     = Regex("""fun\s+(\w+)\s*\(""")
-
-    // ── public ────────────────────────────────────────────────────────────────
-
     fun extractFromFile(file: File): List<SampleMeta> {
         val text = file.readText()
-        val pkg  = packageRe.find(text)?.groupValues?.get(1) ?: ""
-        return extractSamples(text, pkg, file)
-    }
+        val ktFile = psiFactory.createFile(file.name, text)
 
-    // ── extraction ────────────────────────────────────────────────────────────
-
-    private fun extractSamples(text: String, pkg: String, file: File): List<SampleMeta> {
+        val pkg = ktFile.packageFqName.asString()
         val result = mutableListOf<SampleMeta>()
-        var pos = 0
 
-        while (pos < text.length) {
-            val annMatch = docSampleRe.find(text, pos) ?: break
-            val id = annMatch.groupValues[1]
-
-            val funMatch = funRe.find(text, annMatch.range.last + 1) ?: break
-            val funName  = funMatch.groupValues[1]
-            val fqName   = if (pkg.isBlank()) funName else "$pkg.$funName"
-
-            val bodyOpen = text.indexOf('{', funMatch.range.last)
-            if (bodyOpen == -1) { pos = annMatch.range.last + 1; continue }
-
-            val bodyClose = matchingBrace(text, bodyOpen)
-            if (bodyClose == -1) { pos = annMatch.range.last + 1; continue }
-
-            val funBody       = text.substring(bodyOpen + 1, bodyClose)
-            val funBodyOffset = bodyOpen + 1
-
-            val calls = findSnippetCalls(funBody, funBodyOffset)
-            if (calls.isEmpty()) { pos = bodyClose + 1; continue }
-
-            var hasComposable = false
-            var hasRegular    = false
-            var minStart      = Int.MAX_VALUE
-            var maxEnd        = Int.MIN_VALUE
-            val blocks        = mutableListOf<String>()
-
-            for (call in calls) {
-                when (call.type) {
-                    "composableCodeSnippet" -> hasComposable = true
-                    else                    -> hasRegular    = true
-                }
-                val callIndent  = indentBefore(text, call.callAbsStart)
-                val normalized  = normalizeIndent(call.lambdaBody, callIndent)
-                val replaced    = replacePlaceholders(normalized)
-                if (replaced.isNotBlank()) {
-                    blocks += replaced
-                    minStart = minOf(minStart, call.lambdaAbsRange.first)
-                    maxEnd   = maxOf(maxEnd,   call.lambdaAbsRange.last)
-                }
+        ktFile.declarations
+            .asSequence()
+            .filterIsInstance<KtNamedFunction>()
+            .forEach { fn ->
+                extractFromFunction(
+                    pkg = pkg,
+                    fn = fn,
+                    file = file,
+                    fileText = text,
+                )?.let(result::add)
             }
-
-            val snippet = blocks.filter { it.isNotBlank() }.joinToString("\n\n").trimEnd()
-            if (snippet.isBlank()) { pos = bodyClose + 1; continue }
-
-            val kind = when {
-                hasComposable && hasRegular -> "mixed"
-                hasComposable               -> "composable"
-                else                        -> "regular"
-            }
-
-            val relPath     = snippetRelPath(pkg, id)
-            val snippetFile = File(snippetsDir, relPath).also { it.parentFile.mkdirs() }
-            snippetFile.writeText(snippet + "\n")
-
-            result += SampleMeta(
-                id                  = id,
-                kind                = kind,
-                fqName              = fqName,
-                file                = project.relativePath(file),
-                snippetPath         = snippetFile.relativeTo(snippetsDir).path,
-                snippetStartOffset  = if (minStart == Int.MAX_VALUE) 0 else minStart,
-                snippetEndOffset    = if (maxEnd   == Int.MIN_VALUE) 0 else maxEnd,
-            )
-
-            pos = bodyClose + 1
-        }
 
         return result
     }
 
-    // ── snippet call finding ──────────────────────────────────────────────────
+    private fun extractFromFunction(
+        pkg: String,
+        fn: KtNamedFunction,
+        file: File,
+        fileText: String,
+    ): SampleMeta? {
+        val docAnn = findDocSampleAnnotation(fn) ?: return null
+        val id = readDocSampleId(docAnn) ?: fn.name ?: return null
+        val funName = fn.name ?: return null
+        val fqName = buildFqName(pkg, funName)
 
-    private data class SnippetCall(
-        val type:            String,
-        val lambdaBody:      String,
-        val lambdaAbsRange:  IntRange,
-        val callAbsStart:    Int,
-    )
+        val calls = collectSnippetCalls(fn)
+        if (calls.isEmpty()) return null
 
-    private fun findSnippetCalls(body: String, bodyAbsOffset: Int): List<SnippetCall> {
-        val result = mutableListOf<SnippetCall>()
-        var pos = 0
-        while (pos < body.length) {
-            val m = snippetCallRe.find(body, pos) ?: break
-            val braceOpen  = m.range.last          // the '{' captured by the regex
-            val braceClose = matchingBrace(body, braceOpen)
-            if (braceClose == -1) { pos = m.range.last + 1; continue }
+        val blocks = mutableListOf<String>()
+        var hasRegular = false
+        var hasComposable = false
+        var minStart = Int.MAX_VALUE
+        var maxEnd = Int.MIN_VALUE
 
-            result += SnippetCall(
-                type           = m.groupValues[1],
-                lambdaBody     = body.substring(braceOpen + 1, braceClose),
-                lambdaAbsRange = (bodyAbsOffset + braceOpen + 1)..(bodyAbsOffset + braceClose),
-                callAbsStart   = bodyAbsOffset + m.range.first,
-            )
-            pos = braceClose + 1
-        }
-        return result
-    }
-
-    // ── brace matching ────────────────────────────────────────────────────────
-
-    private fun matchingBrace(text: String, openPos: Int): Int {
-        var depth  = 0
-        var inStr  = false
-        var escape = false
-        var i      = openPos
-        while (i < text.length) {
-            when {
-                escape         -> escape = false
-                text[i] == '\\' && inStr -> escape = true
-                text[i] == '"'  -> inStr = !inStr
-                !inStr && text[i] == '{' -> depth++
-                !inStr && text[i] == '}' -> { if (--depth == 0) return i }
+        calls.forEach { call ->
+            when (call.calleeExpression?.text) {
+                "composableCodeSnippet" -> hasComposable = true
+                else -> hasRegular = true
             }
-            i++
-        }
-        return -1
-    }
 
-    // ── indent helpers ────────────────────────────────────────────────────────
-
-    private fun indentBefore(text: String, offset: Int): String {
-        val lineStart = text.lastIndexOf('\n', offset - 1).let { if (it == -1) 0 else it + 1 }
-        return text.substring(lineStart, offset).takeWhile { it == ' ' || it == '\t' }
-    }
-
-    private fun normalizeIndent(raw: String, callIndent: String): String {
-        val lines = raw.lines().dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
-        if (lines.isEmpty()) return ""
-
-        // determine the indent level of the first content line inside the lambda
-        val firstContentIndent = lines.firstOrNull { it.isNotBlank() }
-            ?.takeWhile { it == ' ' || it == '\t' } ?: ""
-
-        val stripPrefix = if (callIndent.isNotEmpty() && firstContentIndent.startsWith(callIndent))
-            firstContentIndent          // callIndent + relative-lambda-indent
-        else
-            firstContentIndent
-
-        return lines.joinToString("\n") { line ->
-            val trimmed = line.trimEnd()
-            when {
-                stripPrefix.isNotEmpty() && trimmed.startsWith(stripPrefix) ->
-                    trimmed.removePrefix(stripPrefix)
-                callIndent.isNotEmpty() && trimmed.startsWith(callIndent) ->
-                    trimmed.removePrefix(callIndent)
-                else -> trimmed
+            extractNormalizedBlock(call, fileText)?.let { (block, range) ->
+                blocks += block
+                minStart = kotlin.math.min(minStart, range.startOffset)
+                maxEnd = kotlin.math.max(maxEnd, range.endOffset)
             }
         }
+
+        val normalizedSnippet = blocks
+            .filter { it.isNotBlank() }
+            .joinToString("\n\n")
+            .trimEnd()
+
+        if (normalizedSnippet.isBlank()) return null
+
+        val kind = when {
+            hasComposable && hasRegular -> "mixed"
+            hasComposable -> "composable"
+            else -> "regular"
+        }
+
+        val snippetStartOffset = if (minStart == Int.MAX_VALUE) 0 else minStart
+        val snippetEndOffset = if (maxEnd == Int.MIN_VALUE) 0 else maxEnd
+
+        val snippetRelPath = buildSnippetRelPath(pkg = pkg, id = id)
+        val snippetFile = File(snippetsDir, snippetRelPath)
+        snippetFile.parentFile.mkdirs()
+        snippetFile.writeText(normalizedSnippet + "\n")
+
+        return SampleMeta(
+            id = id,
+            kind = kind,
+            fqName = fqName,
+            file = project.relativePath(file),
+            snippetPath = snippetFile.relativeTo(snippetsDir).path,
+            snippetStartOffset = snippetStartOffset,
+            snippetEndOffset = snippetEndOffset,
+        )
     }
 
-    // ── placeholder replacement ───────────────────────────────────────────────
+    private fun findDocSampleAnnotation(fn: KtNamedFunction): KtAnnotationEntry? {
+        return fn.annotationEntries.firstOrNull { it.shortName?.asString() == "DocSample" }
+    }
 
-    private val placeholderRe =
-        Regex("""placeholder\s*\(\s*[^,]+,\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*\)""")
+    private fun collectSnippetCalls(fn: KtNamedFunction): List<KtCallExpression> {
+        return fn.bodyBlockExpression
+            ?.statements
+            ?.asSequence()
+            ?.flatMap { it.collectDescendantsOfType<KtCallExpression>().asSequence() }
+            ?.filter {
+                val callee = it.calleeExpression?.text
+                callee == "codeSnippet" || callee == "composableCodeSnippet"
+            }
+            ?.toList()
+            .orEmpty()
+    }
 
-    private fun replacePlaceholders(snippet: String): String =
-        snippet.replace(placeholderRe) { it.groupValues[1].trim() }
+    private fun extractNormalizedBlock(
+        call: KtCallExpression,
+        fileText: String,
+    ): Pair<String, org.jetbrains.kotlin.com.intellij.openapi.util.TextRange>? {
+        val lambda = call.lambdaArguments.firstOrNull()?.getLambdaExpression() ?: return null
+        val body = lambda.bodyExpression ?: return null
+        val range = body.textRange
 
-    // ── path helpers ──────────────────────────────────────────────────────────
+        val rawSnippet = fileText.substring(range.startOffset, range.endOffset)
+        val callIndentPrefix = computeCallIndentPrefix(call, fileText)
+        val lambdaIndentRelative = computeLambdaIndentRelative(callIndentPrefix, range, fileText)
 
-    private fun snippetRelPath(pkg: String, id: String): String {
-        fun sanitize(s: String) = s.trim().replace(Regex("[^A-Za-z0-9_.-]"), "_")
-        val safeId  = sanitize(id)
+        val normalized = normalizeIndent(rawSnippet, callIndentPrefix, lambdaIndentRelative)
+        val replaced = replacePlaceholderCalls(normalized)
+
+        return replaced to range
+    }
+
+    private fun computeCallIndentPrefix(call: KtCallExpression, fileText: String): String {
+        val callStart = call.textRange.startOffset
+        val lineStart = fileText.lastIndexOf('\n', startIndex = callStart).let { if (it == -1) 0 else it + 1 }
+        val beforeCall = fileText.substring(lineStart, callStart)
+        return beforeCall.takeWhile { it == ' ' || it == '\t' }
+    }
+
+    private fun computeLambdaIndentRelative(
+        callIndentPrefix: String,
+        bodyRange: org.jetbrains.kotlin.com.intellij.openapi.util.TextRange,
+        fileText: String,
+    ): String {
+        val bodyStart = bodyRange.startOffset
+        val lineStart = fileText.lastIndexOf('\n', startIndex = bodyStart).let { if (it == -1) 0 else it + 1 }
+        val beforeBody = fileText.substring(lineStart, bodyStart)
+        val lambdaBodyIndentPrefix = beforeBody.takeWhile { it == ' ' || it == '\t' }
+
+        return if (callIndentPrefix.isNotEmpty() && lambdaBodyIndentPrefix.startsWith(callIndentPrefix)) {
+            lambdaBodyIndentPrefix.removePrefix(callIndentPrefix)
+        } else {
+            lambdaBodyIndentPrefix
+        }
+    }
+
+    private fun normalizeIndent(
+        rawSnippet: String,
+        callIndentPrefix: String,
+        lambdaIndentRelative: String,
+    ): String {
+        return rawSnippet
+            .lines()
+            .dropWhile { it.isBlank() }
+            .dropLastWhile { it.isBlank() }
+            .map { line ->
+                var s = line.trimEnd()
+
+                // 1) Shift by the indentation of the call-site.
+                if (callIndentPrefix.isNotEmpty() && s.startsWith(callIndentPrefix)) {
+                    s = s.removePrefix(callIndentPrefix)
+                }
+
+                // 2) Shift by the indentation level inside the lambda (relative to the call-site indent).
+                if (lambdaIndentRelative.isNotEmpty() && s.startsWith(lambdaIndentRelative)) {
+                    s = s.removePrefix(lambdaIndentRelative)
+                }
+
+                s
+            }
+            .joinToString("\n")
+    }
+
+    private fun replacePlaceholderCalls(snippet: String): String {
+        val re = "placeholder\\s*\\(\\s*[^,]+,\\s*\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"\\s*\\)".toRegex()
+        return snippet.replace(re) { m -> m.groupValues[1].trim() }
+    }
+
+    private fun readDocSampleId(ann: KtAnnotationEntry): String? {
+        // @DocSample(id = "x") or @DocSample("x")
+        val args = ann.valueArguments
+        if (args.isEmpty()) return null
+
+        // Named id=
+        val named = args.firstOrNull { it.getArgumentName()?.asName?.asString() == "id" }
+        val arg = named ?: args.first()
+
+        val expr = arg.getArgumentExpression() as? KtStringTemplateExpression ?: return null
+        // Support only literal strings in MVP
+        return expr.entries.joinToString("") { it.text }.trim('"')
+    }
+
+    private fun buildFqName(pkg: String, funName: String): String =
+        if (pkg.isBlank()) funName else "$pkg.$funName"
+
+    private fun buildSnippetRelPath(pkg: String, id: String): String {
+        fun sanitizeSegment(s: String): String = s
+            .trim()
+            .replace(Regex("[^A-Za-z0-9_.-]"), "_")
+
+        val safeId = sanitizeSegment(id)
         val pkgPath = pkg.takeIf { it.isNotBlank() }
-            ?.split('.')?.joinToString(File.separator) { sanitize(it) } ?: ""
-        return if (pkgPath.isBlank()) "$safeId.kt" else "$pkgPath${File.separator}$safeId.kt"
+            ?.split('.')
+            ?.joinToString(File.separator) { sanitizeSegment(it) }
+            ?: ""
+
+        return if (pkgPath.isBlank()) {
+            "$safeId.kt"
+        } else {
+            pkgPath + File.separator + "$safeId.kt"
+        }
     }
 }

--- a/build-system/conventions/src/main/kotlin/tasks/docs/KotlinSnippetExtractorDelegate.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/KotlinSnippetExtractorDelegate.kt
@@ -1,6 +1,5 @@
 package tasks.docs
 
-import org.gradle.api.Project
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -12,7 +11,7 @@ import java.io.File
 internal class KotlinSnippetExtractorDelegate(
     private val psiFactory: KtPsiFactory,
     private val snippetsDir: File,
-    private val project: Project,
+    private val projectDir: File,
 ) {
     fun extractFromFile(file: File): List<SampleMeta> {
         val text = file.readText()
@@ -94,7 +93,7 @@ internal class KotlinSnippetExtractorDelegate(
             id = id,
             kind = kind,
             fqName = fqName,
-            file = project.relativePath(file),
+            file = relativePath(projectDir, file),
             snippetPath = snippetFile.relativeTo(snippetsDir).path,
             snippetStartOffset = snippetStartOffset,
             snippetEndOffset = snippetEndOffset,

--- a/build-system/conventions/src/main/kotlin/tasks/docs/KotlinSnippetExtractorDelegate.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/KotlinSnippetExtractorDelegate.kt
@@ -1,229 +1,202 @@
 package tasks.docs
 
 import org.gradle.api.Project
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtPsiFactory
-import org.jetbrains.kotlin.psi.KtStringTemplateExpression
-import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import java.io.File
 
 internal class KotlinSnippetExtractorDelegate(
-    private val psiFactory: KtPsiFactory,
     private val snippetsDir: File,
     private val project: Project,
 ) {
+    // @DocSample("id")  or  @DocSample(id = "id")
+    private val docSampleRe = Regex(
+        """@DocSample\s*\(\s*(?:id\s*=\s*)?\"([^\"]+)\"\s*\)"""
+    )
+    private val snippetCallRe = Regex(
+        """(composableCodeSnippet|codeSnippet)\s*\{"""
+    )
+    private val packageRe = Regex("""^\s*package\s+([\w.]+)""", RegexOption.MULTILINE)
+    private val funRe     = Regex("""fun\s+(\w+)\s*\(""")
+
+    // ── public ────────────────────────────────────────────────────────────────
+
     fun extractFromFile(file: File): List<SampleMeta> {
         val text = file.readText()
-        val ktFile = psiFactory.createFile(file.name, text)
+        val pkg  = packageRe.find(text)?.groupValues?.get(1) ?: ""
+        return extractSamples(text, pkg, file)
+    }
 
-        val pkg = ktFile.packageFqName.asString()
+    // ── extraction ────────────────────────────────────────────────────────────
+
+    private fun extractSamples(text: String, pkg: String, file: File): List<SampleMeta> {
         val result = mutableListOf<SampleMeta>()
+        var pos = 0
 
-        ktFile.declarations
-            .asSequence()
-            .filterIsInstance<KtNamedFunction>()
-            .forEach { fn ->
-                extractFromFunction(
-                    pkg = pkg,
-                    fn = fn,
-                    file = file,
-                    fileText = text,
-                )?.let(result::add)
+        while (pos < text.length) {
+            val annMatch = docSampleRe.find(text, pos) ?: break
+            val id = annMatch.groupValues[1]
+
+            val funMatch = funRe.find(text, annMatch.range.last + 1) ?: break
+            val funName  = funMatch.groupValues[1]
+            val fqName   = if (pkg.isBlank()) funName else "$pkg.$funName"
+
+            val bodyOpen = text.indexOf('{', funMatch.range.last)
+            if (bodyOpen == -1) { pos = annMatch.range.last + 1; continue }
+
+            val bodyClose = matchingBrace(text, bodyOpen)
+            if (bodyClose == -1) { pos = annMatch.range.last + 1; continue }
+
+            val funBody       = text.substring(bodyOpen + 1, bodyClose)
+            val funBodyOffset = bodyOpen + 1
+
+            val calls = findSnippetCalls(funBody, funBodyOffset)
+            if (calls.isEmpty()) { pos = bodyClose + 1; continue }
+
+            var hasComposable = false
+            var hasRegular    = false
+            var minStart      = Int.MAX_VALUE
+            var maxEnd        = Int.MIN_VALUE
+            val blocks        = mutableListOf<String>()
+
+            for (call in calls) {
+                when (call.type) {
+                    "composableCodeSnippet" -> hasComposable = true
+                    else                    -> hasRegular    = true
+                }
+                val callIndent  = indentBefore(text, call.callAbsStart)
+                val normalized  = normalizeIndent(call.lambdaBody, callIndent)
+                val replaced    = replacePlaceholders(normalized)
+                if (replaced.isNotBlank()) {
+                    blocks += replaced
+                    minStart = minOf(minStart, call.lambdaAbsRange.first)
+                    maxEnd   = maxOf(maxEnd,   call.lambdaAbsRange.last)
+                }
             }
+
+            val snippet = blocks.filter { it.isNotBlank() }.joinToString("\n\n").trimEnd()
+            if (snippet.isBlank()) { pos = bodyClose + 1; continue }
+
+            val kind = when {
+                hasComposable && hasRegular -> "mixed"
+                hasComposable               -> "composable"
+                else                        -> "regular"
+            }
+
+            val relPath     = snippetRelPath(pkg, id)
+            val snippetFile = File(snippetsDir, relPath).also { it.parentFile.mkdirs() }
+            snippetFile.writeText(snippet + "\n")
+
+            result += SampleMeta(
+                id                  = id,
+                kind                = kind,
+                fqName              = fqName,
+                file                = project.relativePath(file),
+                snippetPath         = snippetFile.relativeTo(snippetsDir).path,
+                snippetStartOffset  = if (minStart == Int.MAX_VALUE) 0 else minStart,
+                snippetEndOffset    = if (maxEnd   == Int.MIN_VALUE) 0 else maxEnd,
+            )
+
+            pos = bodyClose + 1
+        }
 
         return result
     }
 
-    private fun extractFromFunction(
-        pkg: String,
-        fn: KtNamedFunction,
-        file: File,
-        fileText: String,
-    ): SampleMeta? {
-        val docAnn = findDocSampleAnnotation(fn) ?: return null
-        val id = readDocSampleId(docAnn) ?: fn.name ?: return null
-        val funName = fn.name ?: return null
-        val fqName = buildFqName(pkg, funName)
+    // ── snippet call finding ──────────────────────────────────────────────────
 
-        val calls = collectSnippetCalls(fn)
-        if (calls.isEmpty()) return null
+    private data class SnippetCall(
+        val type:            String,
+        val lambdaBody:      String,
+        val lambdaAbsRange:  IntRange,
+        val callAbsStart:    Int,
+    )
 
-        val blocks = mutableListOf<String>()
-        var hasRegular = false
-        var hasComposable = false
-        var minStart = Int.MAX_VALUE
-        var maxEnd = Int.MIN_VALUE
+    private fun findSnippetCalls(body: String, bodyAbsOffset: Int): List<SnippetCall> {
+        val result = mutableListOf<SnippetCall>()
+        var pos = 0
+        while (pos < body.length) {
+            val m = snippetCallRe.find(body, pos) ?: break
+            val braceOpen  = m.range.last          // the '{' captured by the regex
+            val braceClose = matchingBrace(body, braceOpen)
+            if (braceClose == -1) { pos = m.range.last + 1; continue }
 
-        calls.forEach { call ->
-            when (call.calleeExpression?.text) {
-                "composableCodeSnippet" -> hasComposable = true
-                else -> hasRegular = true
-            }
-
-            extractNormalizedBlock(call, fileText)?.let { (block, range) ->
-                blocks += block
-                minStart = kotlin.math.min(minStart, range.startOffset)
-                maxEnd = kotlin.math.max(maxEnd, range.endOffset)
-            }
+            result += SnippetCall(
+                type           = m.groupValues[1],
+                lambdaBody     = body.substring(braceOpen + 1, braceClose),
+                lambdaAbsRange = (bodyAbsOffset + braceOpen + 1)..(bodyAbsOffset + braceClose),
+                callAbsStart   = bodyAbsOffset + m.range.first,
+            )
+            pos = braceClose + 1
         }
-
-        val normalizedSnippet = blocks
-            .filter { it.isNotBlank() }
-            .joinToString("\n\n")
-            .trimEnd()
-
-        if (normalizedSnippet.isBlank()) return null
-
-        val kind = when {
-            hasComposable && hasRegular -> "mixed"
-            hasComposable -> "composable"
-            else -> "regular"
-        }
-
-        val snippetStartOffset = if (minStart == Int.MAX_VALUE) 0 else minStart
-        val snippetEndOffset = if (maxEnd == Int.MIN_VALUE) 0 else maxEnd
-
-        val snippetRelPath = buildSnippetRelPath(pkg = pkg, id = id)
-        val snippetFile = File(snippetsDir, snippetRelPath)
-        snippetFile.parentFile.mkdirs()
-        snippetFile.writeText(normalizedSnippet + "\n")
-
-        return SampleMeta(
-            id = id,
-            kind = kind,
-            fqName = fqName,
-            file = project.relativePath(file),
-            snippetPath = snippetFile.relativeTo(snippetsDir).path,
-            snippetStartOffset = snippetStartOffset,
-            snippetEndOffset = snippetEndOffset,
-        )
+        return result
     }
 
-    private fun findDocSampleAnnotation(fn: KtNamedFunction): KtAnnotationEntry? {
-        return fn.annotationEntries.firstOrNull { it.shortName?.asString() == "DocSample" }
-    }
+    // ── brace matching ────────────────────────────────────────────────────────
 
-    private fun collectSnippetCalls(fn: KtNamedFunction): List<KtCallExpression> {
-        return fn.bodyBlockExpression
-            ?.statements
-            ?.asSequence()
-            ?.flatMap { it.collectDescendantsOfType<KtCallExpression>().asSequence() }
-            ?.filter {
-                val callee = it.calleeExpression?.text
-                callee == "codeSnippet" || callee == "composableCodeSnippet"
+    private fun matchingBrace(text: String, openPos: Int): Int {
+        var depth  = 0
+        var inStr  = false
+        var escape = false
+        var i      = openPos
+        while (i < text.length) {
+            when {
+                escape         -> escape = false
+                text[i] == '\\' && inStr -> escape = true
+                text[i] == '"'  -> inStr = !inStr
+                !inStr && text[i] == '{' -> depth++
+                !inStr && text[i] == '}' -> { if (--depth == 0) return i }
             }
-            ?.toList()
-            .orEmpty()
+            i++
+        }
+        return -1
     }
 
-    private fun extractNormalizedBlock(
-        call: KtCallExpression,
-        fileText: String,
-    ): Pair<String, org.jetbrains.kotlin.com.intellij.openapi.util.TextRange>? {
-        val lambda = call.lambdaArguments.firstOrNull()?.getLambdaExpression() ?: return null
-        val body = lambda.bodyExpression ?: return null
-        val range = body.textRange
+    // ── indent helpers ────────────────────────────────────────────────────────
 
-        val rawSnippet = fileText.substring(range.startOffset, range.endOffset)
-        val callIndentPrefix = computeCallIndentPrefix(call, fileText)
-        val lambdaIndentRelative = computeLambdaIndentRelative(callIndentPrefix, range, fileText)
-
-        val normalized = normalizeIndent(rawSnippet, callIndentPrefix, lambdaIndentRelative)
-        val replaced = replacePlaceholderCalls(normalized)
-
-        return replaced to range
+    private fun indentBefore(text: String, offset: Int): String {
+        val lineStart = text.lastIndexOf('\n', offset - 1).let { if (it == -1) 0 else it + 1 }
+        return text.substring(lineStart, offset).takeWhile { it == ' ' || it == '\t' }
     }
 
-    private fun computeCallIndentPrefix(call: KtCallExpression, fileText: String): String {
-        val callStart = call.textRange.startOffset
-        val lineStart = fileText.lastIndexOf('\n', startIndex = callStart).let { if (it == -1) 0 else it + 1 }
-        val beforeCall = fileText.substring(lineStart, callStart)
-        return beforeCall.takeWhile { it == ' ' || it == '\t' }
-    }
+    private fun normalizeIndent(raw: String, callIndent: String): String {
+        val lines = raw.lines().dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
+        if (lines.isEmpty()) return ""
 
-    private fun computeLambdaIndentRelative(
-        callIndentPrefix: String,
-        bodyRange: org.jetbrains.kotlin.com.intellij.openapi.util.TextRange,
-        fileText: String,
-    ): String {
-        val bodyStart = bodyRange.startOffset
-        val lineStart = fileText.lastIndexOf('\n', startIndex = bodyStart).let { if (it == -1) 0 else it + 1 }
-        val beforeBody = fileText.substring(lineStart, bodyStart)
-        val lambdaBodyIndentPrefix = beforeBody.takeWhile { it == ' ' || it == '\t' }
+        // determine the indent level of the first content line inside the lambda
+        val firstContentIndent = lines.firstOrNull { it.isNotBlank() }
+            ?.takeWhile { it == ' ' || it == '\t' } ?: ""
 
-        return if (callIndentPrefix.isNotEmpty() && lambdaBodyIndentPrefix.startsWith(callIndentPrefix)) {
-            lambdaBodyIndentPrefix.removePrefix(callIndentPrefix)
-        } else {
-            lambdaBodyIndentPrefix
+        val stripPrefix = if (callIndent.isNotEmpty() && firstContentIndent.startsWith(callIndent))
+            firstContentIndent          // callIndent + relative-lambda-indent
+        else
+            firstContentIndent
+
+        return lines.joinToString("\n") { line ->
+            val trimmed = line.trimEnd()
+            when {
+                stripPrefix.isNotEmpty() && trimmed.startsWith(stripPrefix) ->
+                    trimmed.removePrefix(stripPrefix)
+                callIndent.isNotEmpty() && trimmed.startsWith(callIndent) ->
+                    trimmed.removePrefix(callIndent)
+                else -> trimmed
+            }
         }
     }
 
-    private fun normalizeIndent(
-        rawSnippet: String,
-        callIndentPrefix: String,
-        lambdaIndentRelative: String,
-    ): String {
-        return rawSnippet
-            .lines()
-            .dropWhile { it.isBlank() }
-            .dropLastWhile { it.isBlank() }
-            .map { line ->
-                var s = line.trimEnd()
+    // ── placeholder replacement ───────────────────────────────────────────────
 
-                // 1) Shift by the indentation of the call-site.
-                if (callIndentPrefix.isNotEmpty() && s.startsWith(callIndentPrefix)) {
-                    s = s.removePrefix(callIndentPrefix)
-                }
+    private val placeholderRe =
+        Regex("""placeholder\s*\(\s*[^,]+,\s*"([^"\\]*(?:\\.[^"\\]*)*)"\s*\)""")
 
-                // 2) Shift by the indentation level inside the lambda (relative to the call-site indent).
-                if (lambdaIndentRelative.isNotEmpty() && s.startsWith(lambdaIndentRelative)) {
-                    s = s.removePrefix(lambdaIndentRelative)
-                }
+    private fun replacePlaceholders(snippet: String): String =
+        snippet.replace(placeholderRe) { it.groupValues[1].trim() }
 
-                s
-            }
-            .joinToString("\n")
-    }
+    // ── path helpers ──────────────────────────────────────────────────────────
 
-    private fun replacePlaceholderCalls(snippet: String): String {
-        val re = "placeholder\\s*\\(\\s*[^,]+,\\s*\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"\\s*\\)".toRegex()
-        return snippet.replace(re) { m -> m.groupValues[1].trim() }
-    }
-
-    private fun readDocSampleId(ann: KtAnnotationEntry): String? {
-        // @DocSample(id = "x") or @DocSample("x")
-        val args = ann.valueArguments
-        if (args.isEmpty()) return null
-
-        // Named id=
-        val named = args.firstOrNull { it.getArgumentName()?.asName?.asString() == "id" }
-        val arg = named ?: args.first()
-
-        val expr = arg.getArgumentExpression() as? KtStringTemplateExpression ?: return null
-        // Support only literal strings in MVP
-        return expr.entries.joinToString("") { it.text }.trim('"')
-    }
-
-    private fun buildFqName(pkg: String, funName: String): String =
-        if (pkg.isBlank()) funName else "$pkg.$funName"
-
-    private fun buildSnippetRelPath(pkg: String, id: String): String {
-        fun sanitizeSegment(s: String): String = s
-            .trim()
-            .replace(Regex("[^A-Za-z0-9_.-]"), "_")
-
-        val safeId = sanitizeSegment(id)
+    private fun snippetRelPath(pkg: String, id: String): String {
+        fun sanitize(s: String) = s.trim().replace(Regex("[^A-Za-z0-9_.-]"), "_")
+        val safeId  = sanitize(id)
         val pkgPath = pkg.takeIf { it.isNotBlank() }
-            ?.split('.')
-            ?.joinToString(File.separator) { sanitizeSegment(it) }
-            ?: ""
-
-        return if (pkgPath.isBlank()) {
-            "$safeId.kt"
-        } else {
-            pkgPath + File.separator + "$safeId.kt"
-        }
+            ?.split('.')?.joinToString(File.separator) { sanitize(it) } ?: ""
+        return if (pkgPath.isBlank()) "$safeId.kt" else "$pkgPath${File.separator}$safeId.kt"
     }
 }

--- a/build-system/conventions/src/main/kotlin/tasks/docs/XmlSnippetExtractorDelegate.kt
+++ b/build-system/conventions/src/main/kotlin/tasks/docs/XmlSnippetExtractorDelegate.kt
@@ -1,11 +1,10 @@
 package tasks.docs
 
-import org.gradle.api.Project
 import java.io.File
 
 internal class XmlSnippetExtractorDelegate(
     private val snippetsDir: File,
-    private val project: Project,
+    private val projectDir: File,
     private val namespace: String,
 ) {
 
@@ -43,7 +42,7 @@ internal class XmlSnippetExtractorDelegate(
                 id = id,
                 kind = "xml",
                 fqName = "xml.$id",
-                file = project.relativePath(file),
+                file = relativePath(projectDir, file),
                 snippetPath = outFile.relativeTo(snippetsDir).path,
                 snippetStartOffset = if (sampleStartOffset >= 0) sampleStartOffset else 0,
                 snippetEndOffset = if (sampleEndOffset >= 0) sampleEndOffset else 0,

--- a/build-system/gradle/wrapper/gradle-wrapper.properties
+++ b/build-system/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 22 10:32:29 MSK 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-global-gradle = "8.3.2"
+global-gradle = "8.8.2"
 global-jvmTarget = "1.8"
-global-kotlin = "1.9.25"
+global-kotlin = "2.1.10"
 global-compileSdk = "35"
 global-targetSdk = "35"
 global-minSdk = "24"
@@ -30,8 +30,7 @@ androidX-recyclerView = "1.1.0"
 test-espresso = "3.4.0"
 test-jUnit = "4.13.2"
 test-jUnitIntegration = "1.1.5"
-test-mockk = "1.12.2"
-test-paparazzi = "1.1.0"
+test-mockk = "1.14.2"
 test-robolectric = "4.10"
 test-androidX-rules = "1.5.0"
 test-androidX-runner = "1.5.2"
@@ -39,7 +38,7 @@ test-roborazzi = "1.44.0"
 test-assertk = "0.28.1"
 
 kotlinSerialization = "1.4.0"
-kotlinKsp = "1.9.25-1.0.20"
+kotlinKsp = "2.1.10-1.0.31"
 kotlinPoet = "1.12.0"
 kotlinCoroutines = "1.6.1"
 glide = "4.16.0"
@@ -58,7 +57,7 @@ plugin-gradleNexusPublish = "1.3.0"
 plugin-gradlePluginPublish = "1.2.1"
 plugin-binary-compatibility-validator = "0.14.0"
 plugin-compose-multiplatform = "1.7.3"
-plugin-poko = "0.15.3"
+plugin-poko = "0.18.0"
 plugin-metalava = "0.3.5"
 
 plugin-dokka = "1.8.20"
@@ -96,6 +95,7 @@ base-kotlin-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-seria
 base-kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet"}
 base-kotlin-poetKsp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet"}
 base-kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "global-kotlin"}
+base-kotlin-compose-compiler = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "global-kotlin" }
 base-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines"}
 
 base-staticAnalysis-ktlint = { module = "com.pinterest:ktlint", version.ref = "staticAnalysis-ktlint" }
@@ -122,7 +122,6 @@ base-test-ui-compose-uiTestManifest = { module = "androidx.compose.ui:ui-test-ma
 base-gradle-android = { module = "com.android.tools.build:gradle", version.ref = "global-gradle" }
 base-gradle-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "staticAnalysis-detekt" }
 base-gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "global-kotlin" }
-base-gradle-paparazzi = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "test-paparazzi" }
 base-gradle-spotless= { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "staticAnalysis-spotless" }
 base-gradle-cacheFix= { module = "org.gradle.android.cache-fix:org.gradle.android.cache-fix.gradle.plugin", version.ref = "plugin-androidCacheFix" }
 base-gradle-nexusPublish= { module = "io.github.gradle-nexus:publish-plugin", version.ref = "plugin-gradleNexusPublish" }
@@ -156,7 +155,6 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "global-kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "global-kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "global-kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kotlinKsp" }
-paparazzi = { id = "app.cash.paparazzi", version.ref = "test-paparazzi" }
 jgp = { id = "java-gradle-plugin" }
 android-cache-fix = { id = "org.gradle.android.cache-fix", version.ref= "plugin-androidCacheFix" }
 gradleNexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "plugin-gradleNexusPublish" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Feb 07 16:56:30 MSK 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.android.cache.fix) apply false
-    alias(libs.plugins.paparazzi) apply false
 }
 
 buildscript {
@@ -29,7 +28,6 @@ buildscript {
         classpath(libs.base.gradle.kotlin)
         classpath(libs.base.gradle.detekt)
         classpath(libs.base.gradle.spotless)
-        classpath(libs.base.gradle.paparazzi)
         classpath(libs.base.gradle.cacheFix)
         classpath(files("../build-system/libs/star-dimens.jar"))
     }

--- a/playground/gradle/wrapper/gradle-wrapper.properties
+++ b/playground/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 04 17:09:42 MSK 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sdds-core/build.gradle.kts
+++ b/sdds-core/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.android.cache.fix) apply false
-    alias(libs.plugins.paparazzi) apply false
     alias(libs.plugins.gradlePluginPublish) apply false
     alias(libs.plugins.ksp) apply false
 }
@@ -27,7 +26,6 @@ buildscript {
         classpath(libs.base.gradle.kotlin)
         classpath(libs.base.gradle.detekt)
         classpath(libs.base.gradle.spotless)
-        classpath(libs.base.gradle.paparazzi)
         classpath(libs.base.gradle.cacheFix)
     }
 }

--- a/sdds-core/docs/build.gradle.kts
+++ b/sdds-core/docs/build.gradle.kts
@@ -1,3 +1,5 @@
 plugins {
     id("convention.kotlin-lib")
 }
+
+group = "sdds-core"

--- a/sdds-core/gradle/wrapper/gradle-wrapper.properties
+++ b/sdds-core/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 22 11:08:38 MSK 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sdds-core/uikit-compose/build.gradle.kts
+++ b/sdds-core/uikit-compose/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     id("convention.compose")
     id("convention.auto-bump")
     id("convention.dokka")
-    alias(libs.plugins.paparazzi)
     alias(libs.plugins.binary.compatibility.validator)
 }
 
@@ -13,15 +12,18 @@ group = "sdds-core"
 
 android {
     namespace = "com.sdds.compose.uikit"
+}
 
-    kotlinOptions {
-        //comment following lines (freeCompilerArgs) to disable compose-metrics
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + project.buildDir.absolutePath + "/compose_metrics")
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination="  + project.buildDir.absolutePath + "/compose_metrics")
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            listOf(
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.buildDir.absolutePath}/compose_metrics",
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.buildDir.absolutePath}/compose_metrics"
+            )
+        )
     }
 }
 

--- a/sdds-core/uikit/build.gradle.kts
+++ b/sdds-core/uikit/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("convention.maven-publish")
     id("convention.auto-bump")
     id("convention.dokka")
-    alias(libs.plugins.paparazzi)
     alias(libs.plugins.binary.compatibility.validator)
 }
 


### PR DESCRIPTION
- Обновлена версия kotlin 1.9.25 -> 2.1.10
- Обновлена версия gradle 8.3.2 -> 8.8.2
- Обновлена версия gradleWrapper 8.6 -> 8.13
- Удалена зависимость Paparazzi (не используется в проекте)
- Таска ExtractCodeSnippetsTask переведена на Gradle Workers API, чтобы убрать конфликт с kotlin-compiler-embeddable (https://kotlinlang.org/docs/whatsnew21.html#compiler-symbols-hidden-from-the-kotlin-gradle-plugin-api)