### PR TITLE
PLASMA-7152: feat(sdds-acore/uikit-compose): Tabs now can be stretched in scroll mode.

### DIFF
--- a/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
+++ b/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
@@ -282,6 +282,7 @@ private fun CommonTabsContent(
             Box(contentAlignment = Alignment.Center) {
                 VerticalPager(
                     state = pagerState,
+                    userScrollEnabled = state.enabled,
                     modifier = Modifier
                         .fillMaxHeight()
                         .width(200.dp),
@@ -296,6 +297,7 @@ private fun CommonTabsContent(
             Box(contentAlignment = Alignment.Center) {
                 HorizontalPager(
                     state = pagerState,
+                    userScrollEnabled = state.enabled,
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(200.dp),

--- a/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
+++ b/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
@@ -199,6 +199,7 @@ object IconTabsStory : ComposeBaseStory<TabsUiState, TabsStyle>(
                         },
                         counter = counter(state, tabMotion.context),
                         action = actionIconContent(state, style),
+                        enabled = state.enabled,
                         content = {
                             Icon(
                                 source = resourceImageSource(R.drawable.ic_plasma_24),

--- a/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
+++ b/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
@@ -1,15 +1,22 @@
 package com.sdds.compose.uikit.fixtures.stories.tabs
 
+import android.util.Log
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -26,6 +33,7 @@ import com.sdds.compose.uikit.TabItem
 import com.sdds.compose.uikit.TabScope
 import com.sdds.compose.uikit.Tabs
 import com.sdds.compose.uikit.TabsClip
+import com.sdds.compose.uikit.TabsOrientation
 import com.sdds.compose.uikit.TabsStyle
 import com.sdds.compose.uikit.Text
 import com.sdds.compose.uikit.fixtures.stories.TabsUiStatePropertiesProducer
@@ -81,6 +89,9 @@ object TabsStory : ComposeBaseStory<TabsUiState, TabsStyle>(
     TabsUiStatePropertiesProducer,
     TabsUiStateTransformer,
 ) {
+
+    private const val TAG = "TabsStory"
+
     @Composable
     override fun BoxScope.Content(
         style: TabsStyle,
@@ -96,15 +107,21 @@ object TabsStory : ComposeBaseStory<TabsUiState, TabsStyle>(
                     val tabMotion = rememberTabItemPagerMotion(index, pagerState)
                     val isTabSelected = rememberTabSelectedState(index, pagerState)
                     TabItem(
+                        modifier = Modifier.combinedClickable(
+                            interactionSource = tabMotion.context.interactionSource,
+                            indication = null,
+                            onClick = {
+                                scope.launch {
+                                    pagerState.animateScrollToPage(
+                                        index,
+                                        pagerState.currentPageOffsetFraction,
+                                    )
+                                }
+                            },
+                            onLongClick = { Log.d(TAG, "Tabs: long click on tab$index") },
+                        ),
                         isSelected = isTabSelected.value,
-                        onClick = {
-                            scope.launch {
-                                pagerState.animateScrollToPage(
-                                    index,
-                                    pagerState.currentPageOffsetFraction,
-                                )
-                            }
-                        },
+                        onClick = {},
                         content = { Text(stringSource(label)) },
                         helperContent = { Text(stringSource(state.tabItemValue)) },
                         counter = counter(state, tabMotion.context),
@@ -232,33 +249,59 @@ private fun CommonTabsContent(
     style: TabsStyle,
     tabs: TabScope.() -> Unit,
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Tabs(
-            style = style,
-            enabled = state.enabled,
-            selectedTabIndexProvider = { pagerState.currentPage },
-            selectedTabOffset = { pagerState.currentPageOffsetFraction },
-            onDisclosureTabClicked = {
-                scope.launch {
-                    pagerState.animateScrollToPage(it, pagerState.currentPageOffsetFraction)
-                }
-            },
-            clip = state.clip,
-            stretch = state.stretch,
-            indicatorEnabled = state.indicatorEnabled,
-            dividerEnabled = state.dividerEnabled,
-            tabs = tabs,
-        )
-
-        Box(contentAlignment = Alignment.Center) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp),
-                pageContent = {},
+    val content = remember(state, style) {
+        movableContentOf {
+            val sizeModifier = when {
+                style.orientation == TabsOrientation.Horizontal && state.stretch -> Modifier.fillMaxWidth()
+                style.orientation == TabsOrientation.Vertical && state.stretch -> Modifier.fillMaxHeight()
+                else -> Modifier
+            }
+            Tabs(
+                modifier = sizeModifier,
+                style = style,
+                enabled = state.enabled,
+                selectedTabIndexProvider = { pagerState.currentPage },
+                selectedTabOffset = { pagerState.currentPageOffsetFraction },
+                onDisclosureTabClicked = {
+                    scope.launch {
+                        pagerState.animateScrollToPage(it, pagerState.currentPageOffsetFraction)
+                    }
+                },
+                clip = state.clip,
+                stretch = state.stretch,
+                indicatorEnabled = state.indicatorEnabled,
+                dividerEnabled = state.dividerEnabled,
+                tabs = tabs,
             )
-            Text("Swipe here to change tabs")
+        }
+    }
+    if (style.orientation == TabsOrientation.Vertical) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            content()
+            Box(contentAlignment = Alignment.Center) {
+                VerticalPager(
+                    state = pagerState,
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(200.dp),
+                    pageContent = {},
+                )
+                Text("Swipe here to change tabs")
+            }
+        }
+    } else {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            content()
+            Box(contentAlignment = Alignment.Center) {
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    pageContent = {},
+                )
+                Text("Swipe here to change tabs")
+            }
         }
     }
 }

--- a/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
+++ b/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/stories/tabs/TabsStory.kt
@@ -110,6 +110,7 @@ object TabsStory : ComposeBaseStory<TabsUiState, TabsStyle>(
                         modifier = Modifier.combinedClickable(
                             interactionSource = tabMotion.context.interactionSource,
                             indication = null,
+                            enabled = state.enabled,
                             onClick = {
                                 scope.launch {
                                     pagerState.animateScrollToPage(

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/BaseTabItem.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/BaseTabItem.kt
@@ -68,13 +68,14 @@ internal fun BaseTabItem(
         Modifier
     }
     Row(
-        modifier = modifier
+        modifier = Modifier
             .defaultMinSize(
                 minHeight = style.dimensions.minHeight,
                 minWidth = style.dimensions.minWidth,
             )
             .selection(isSelected, motion.context.interactionSource)
             .then(clickableModifier)
+            .then(modifier)
             .backgroundBrush(
                 brushProducer = { backgroundColor.value },
                 shape = style.shape,

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/BaseTabs.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/BaseTabs.kt
@@ -84,6 +84,9 @@ internal fun BaseTabs(
         val overFlowPrevIcon: Int? = style.overflowPrevIcon
         val dropdownTriggerInfo = remember { mutableStateOf(TriggerInfo()) }
         val showDropdown = remember { mutableStateOf(false) }
+        val showScrollControls = remember(clip, stretch, orientation) {
+            mutableStateOf(clip == TabsClip.Scroll && !stretch)
+        }
         Layout(
             modifier = Modifier
                 .clip(style.shape)
@@ -107,17 +110,17 @@ internal fun BaseTabs(
                 val coroutineScope = rememberCoroutineScope()
                 val canStretch = stretch && clip != TabsClip.Scroll
                 val spacingDp = getItemSpacing(style.dimensions.minSpacing, canStretch)
-                val spacingPx = with(LocalDensity.current) {
-                    spacingDp.roundToPx()
+                val minSpacingPx = with(LocalDensity.current) {
+                    style.dimensions.minSpacing.roundToPx()
                 }
                 val tabSizes = remember { mutableStateListOf<Int>() }
                 StartControl(
-                    overFlowIcon = overFlowPrevIcon,
+                    overFlowIcon = if (showScrollControls.value) overFlowPrevIcon else null,
                     clip = clip,
                     coroutineScope = coroutineScope,
                     scrollState = scrollState,
                     tabSizes = tabSizes,
-                    spacingPx = spacingPx,
+                    spacingPx = minSpacingPx,
                     color = style.colors.overflowPrevIconColor,
                     interactionSource = interactionSource,
                     enabled = enabled,
@@ -133,8 +136,10 @@ internal fun BaseTabs(
                     onTabClicked = onTabClicked,
                     clip = clip,
                     canStretch = canStretch,
+                    stretchForScroll = stretch && clip == TabsClip.Scroll,
                     spacingDp = spacingDp,
-                    spacingPx = spacingPx,
+                    minSpacingDp = style.dimensions.minSpacing,
+                    spacingPx = minSpacingPx,
                     scrollState = scrollState,
                     coroutineScope = coroutineScope,
                     indicatorEnabled = indicatorEnabled,
@@ -146,14 +151,19 @@ internal fun BaseTabs(
                     tabs = tabScope.tabs.map { it.main },
                     disclosureContent = tabScope.disclosureContent,
                     onOverflowTab = { overflowIndex = it },
+                    onScrollControlsVisibilityChange = { visible ->
+                        if (showScrollControls.value != visible) {
+                            showScrollControls.value = visible
+                        }
+                    },
                 )
                 EndControl(
-                    overFlowIcon = overFlowNextIcon,
+                    overFlowIcon = if (showScrollControls.value) overFlowNextIcon else null,
                     clip = clip,
                     coroutineScope = coroutineScope,
                     scrollState = scrollState,
                     tabSizes = tabSizes,
-                    spacingPx = spacingPx,
+                    spacingPx = minSpacingPx,
                     color = style.colors.overflowNextIconColor,
                     interactionSource = interactionSource,
                     enabled = enabled,

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/container/HorizontalTabsContainer.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/container/HorizontalTabsContainer.kt
@@ -5,14 +5,18 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import com.sdds.compose.uikit.TabsClip
 import com.sdds.compose.uikit.TabsOrientation
 import com.sdds.compose.uikit.TabsStyle
@@ -30,7 +34,9 @@ internal fun HorizontalTabsContainer(
     onTabClicked: ((Int) -> Unit)? = null,
     clip: TabsClip,
     spacingDp: Dp,
+    minSpacingDp: Dp,
     canStretch: Boolean,
+    stretchForScroll: Boolean,
     scrollState: ScrollState,
     indicatorEnabled: Boolean,
     interactionSource: InteractionSource,
@@ -40,6 +46,7 @@ internal fun HorizontalTabsContainer(
     dropdownTriggerInfo: MutableState<TriggerInfo>,
     onDisclosureClick: () -> Unit,
     onOverflowTab: ((Int) -> Unit)?,
+    onScrollControlsVisibilityChange: ((Boolean) -> Unit)?,
 ) {
     val onTabsMeasured: (Int, IntSize) -> Unit = { index, intSize ->
         tabSizes.apply {
@@ -69,22 +76,40 @@ internal fun HorizontalTabsContainer(
             onTabsMeasured = onTabsMeasured,
         )
     } else {
-        RegularRow(
-            style = style,
-            enabled = enabled,
-            selectedTabIndexProvider = selectedTabIndexProvider,
-            selectedTabOffset = selectedTabOffset,
-            onTabClicked = onTabClicked,
-            clip = clip,
-            spacingDp = spacingDp,
-            canStretch = canStretch,
-            scrollState = scrollState,
-            indicatorEnabled = indicatorEnabled,
-            interactionSource = interactionSource,
-            tabSizes = tabSizes,
-            tabs = tabs,
-            onTabsMeasured = onTabsMeasured,
-        )
+        if (clip == TabsClip.Scroll && stretchForScroll) {
+            AutoStretchScrollableRow(
+                style = style,
+                enabled = enabled,
+                selectedTabIndexProvider = selectedTabIndexProvider,
+                selectedTabOffset = selectedTabOffset,
+                onTabClicked = onTabClicked,
+                minSpacingDp = minSpacingDp,
+                scrollState = scrollState,
+                indicatorEnabled = indicatorEnabled,
+                interactionSource = interactionSource,
+                tabSizes = tabSizes,
+                tabs = tabs,
+                onTabsMeasured = onTabsMeasured,
+                onScrollControlsVisibilityChange = onScrollControlsVisibilityChange,
+            )
+        } else {
+            RegularRow(
+                style = style,
+                enabled = enabled,
+                selectedTabIndexProvider = selectedTabIndexProvider,
+                selectedTabOffset = selectedTabOffset,
+                onTabClicked = onTabClicked,
+                clip = clip,
+                spacingDp = spacingDp,
+                canStretch = canStretch,
+                scrollState = scrollState,
+                indicatorEnabled = indicatorEnabled,
+                interactionSource = interactionSource,
+                tabSizes = tabSizes,
+                tabs = tabs,
+                onTabsMeasured = onTabsMeasured,
+            )
+        }
     }
 }
 
@@ -139,6 +164,110 @@ private fun RegularRow(
             )
         }
     }
+}
+
+@Composable
+private fun AutoStretchScrollableRow(
+    style: TabsStyle,
+    enabled: Boolean,
+    selectedTabIndexProvider: () -> Int,
+    selectedTabOffset: () -> Float,
+    onTabClicked: ((Int) -> Unit)?,
+    minSpacingDp: Dp,
+    scrollState: ScrollState,
+    indicatorEnabled: Boolean,
+    interactionSource: InteractionSource,
+    tabSizes: SnapshotStateList<Int>,
+    tabs: List<@Composable (() -> Unit)>,
+    onTabsMeasured: (Int, IntSize) -> Unit,
+    onScrollControlsVisibilityChange: ((Boolean) -> Unit)?,
+) {
+    SubcomposeLayout { constraints ->
+        val measureConstraints = constraints.copy(
+            minWidth = 0,
+            maxWidth = Constraints.Infinity,
+            minHeight = 0,
+        )
+        val naturalWidths = subcompose(AutoStretchScrollableRowSlot.Measure) {
+            tabs.forEach { tabItem ->
+                TabItemContainer(
+                    stretch = false,
+                    enabled = enabled,
+                    onClick = null,
+                    onSizeMeasured = {},
+                    tabItemStyle = style.tabItemStyle,
+                    tabItemContent = tabItem,
+                )
+            }
+        }.map { measurable ->
+            measurable.measure(measureConstraints).width
+        }
+
+        val totalNaturalWidth = naturalWidths.sum() +
+            minSpacingDp.roundToPx() * (naturalWidths.size - 1).coerceAtLeast(0)
+        val canStretchWithoutScroll = totalNaturalWidth <= constraints.maxWidth
+        onScrollControlsVisibilityChange?.invoke(!canStretchWithoutScroll)
+        val effectiveSpacing = if (canStretchWithoutScroll) 0.dp else minSpacingDp
+        val effectiveClip = if (canStretchWithoutScroll) TabsClip.None else TabsClip.Scroll
+
+        val contentPlaceable = subcompose(AutoStretchScrollableRowSlot.Content) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(effectiveSpacing),
+                modifier = Modifier
+                    .then(
+                        if (canStretchWithoutScroll) {
+                            Modifier.fillMaxWidth()
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .tabIndicator(
+                        indicatorEnabled = indicatorEnabled,
+                        indicatorColor = style.colors.indicatorColor.colorForInteraction(
+                            interactionSource,
+                        ),
+                        indicatorShape = style.indicatorShape,
+                        indicatorThickness = style.dimensions.indicatorThickness,
+                        spacingDp = effectiveSpacing,
+                        tabSizes = tabSizes,
+                        selectedTabIndexProvider = selectedTabIndexProvider,
+                        selectedTabOffset = selectedTabOffset,
+                        scrollState = scrollState,
+                        orientation = TabsOrientation.Horizontal,
+                        clip = effectiveClip,
+                    )
+                    .clipModifier(
+                        clip = effectiveClip,
+                        scrollState = scrollState,
+                        enabled = enabled,
+                        canStretch = canStretchWithoutScroll,
+                    ),
+            ) {
+                tabs.forEachIndexed { index, tabItem ->
+                    TabItemContainer(
+                        modifier = if (canStretchWithoutScroll) Modifier.weight(1f) else Modifier,
+                        enabled = enabled,
+                        stretch = canStretchWithoutScroll,
+                        onClick = { onTabClicked?.invoke(index) },
+                        onSizeMeasured = { intSize ->
+                            onTabsMeasured.invoke(index, intSize)
+                        },
+                        tabItemStyle = style.tabItemStyle,
+                        tabItemContent = tabItem,
+                    )
+                }
+            }
+        }.first().measure(constraints)
+
+        layout(contentPlaceable.width, contentPlaceable.height) {
+            contentPlaceable.placeRelative(0, 0)
+        }
+    }
+}
+
+private enum class AutoStretchScrollableRowSlot {
+    Measure,
+    Content,
 }
 
 @Composable

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/container/TabsContainer.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/container/TabsContainer.kt
@@ -37,8 +37,10 @@ internal fun TabsContainer(
     onTabClicked: ((Int) -> Unit)? = null,
     clip: TabsClip = TabsClip.None,
     spacingDp: Dp,
+    minSpacingDp: Dp,
     spacingPx: Int,
     canStretch: Boolean = false,
+    stretchForScroll: Boolean = false,
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
     scrollState: ScrollState = rememberScrollState(),
     indicatorEnabled: Boolean = style.indicatorEnabled,
@@ -50,6 +52,7 @@ internal fun TabsContainer(
     dropdownTriggerInfo: MutableState<TriggerInfo>,
     onDisclosureClick: () -> Unit,
     onOverflowTab: ((Int) -> Unit)? = null,
+    onScrollControlsVisibilityChange: ((Boolean) -> Unit)? = null,
 ) {
     if (tabs.isEmpty()) return
 
@@ -63,7 +66,9 @@ internal fun TabsContainer(
                 onTabClicked = onTabClicked,
                 clip = clip,
                 spacingDp = spacingDp,
+                minSpacingDp = minSpacingDp,
                 canStretch = canStretch,
+                stretchForScroll = stretchForScroll,
                 scrollState = scrollState,
                 indicatorEnabled = indicatorEnabled,
                 interactionSource = interactionSource,
@@ -73,16 +78,20 @@ internal fun TabsContainer(
                 dropdownTriggerInfo = dropdownTriggerInfo,
                 onDisclosureClick = onDisclosureClick,
                 onOverflowTab = onOverflowTab,
+                onScrollControlsVisibilityChange = onScrollControlsVisibilityChange,
             )
 
             TabsOrientation.Vertical -> VerticalTabsContainer(
                 style = style,
                 enabled = enabled,
                 onTabClicked = onTabClicked,
+                selectedTabOffset = selectedTabOffset,
                 selectedTabIndexProvider = selectedTabIndexProvider,
                 clip = clip,
                 spacingDp = spacingDp,
+                minSpacingDp = minSpacingDp,
                 canStretch = canStretch,
+                stretchForScroll = stretchForScroll,
                 scrollState = scrollState,
                 indicatorEnabled = indicatorEnabled,
                 interactionSource = interactionSource,
@@ -92,6 +101,7 @@ internal fun TabsContainer(
                 dropdownTriggerInfo = dropdownTriggerInfo,
                 onDisclosureClick = onDisclosureClick,
                 onOverflowTab = onOverflowTab,
+                onScrollControlsVisibilityChange = onScrollControlsVisibilityChange,
             )
         }
     }

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/container/VerticalTabsContainer.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/tabs/container/VerticalTabsContainer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -11,8 +12,11 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import com.sdds.compose.uikit.TabsClip
 import com.sdds.compose.uikit.TabsOrientation
 import com.sdds.compose.uikit.TabsStyle
@@ -26,10 +30,13 @@ internal fun VerticalTabsContainer(
     style: TabsStyle,
     enabled: Boolean,
     selectedTabIndexProvider: () -> Int,
+    selectedTabOffset: () -> Float,
     onTabClicked: ((Int) -> Unit)? = null,
     clip: TabsClip,
     spacingDp: Dp,
+    minSpacingDp: Dp,
     canStretch: Boolean,
+    stretchForScroll: Boolean,
     scrollState: ScrollState,
     indicatorEnabled: Boolean,
     interactionSource: InteractionSource,
@@ -39,6 +46,7 @@ internal fun VerticalTabsContainer(
     dropdownTriggerInfo: MutableState<TriggerInfo>,
     onDisclosureClick: () -> Unit,
     onOverflowTab: ((Int) -> Unit)?,
+    onScrollControlsVisibilityChange: ((Boolean) -> Unit)?,
 ) {
     val onTabsMeasured: (Int, IntSize) -> Unit = { index, intSize ->
         tabSizes.apply {
@@ -51,6 +59,7 @@ internal fun VerticalTabsContainer(
             style = style,
             enabled = enabled,
             selectedTabIndexProvider = selectedTabIndexProvider,
+            selectedTabOffset = selectedTabOffset,
             onTabClicked = onTabClicked,
             spacingDp = spacingDp,
             canStretch = canStretch,
@@ -66,21 +75,40 @@ internal fun VerticalTabsContainer(
             onTabsMeasured = onTabsMeasured,
         )
     } else {
-        RegularColumn(
-            style = style,
-            enabled = enabled,
-            selectedTabIndexProvider = selectedTabIndexProvider,
-            onTabClicked = onTabClicked,
-            clip = clip,
-            spacingDp = spacingDp,
-            canStretch = canStretch,
-            scrollState = scrollState,
-            indicatorEnabled = indicatorEnabled,
-            interactionSource = interactionSource,
-            tabSizes = tabSizes,
-            tabs = tabs,
-            onTabsMeasured = onTabsMeasured,
-        )
+        if (clip == TabsClip.Scroll && stretchForScroll) {
+            AutoStretchScrollableColumn(
+                style = style,
+                enabled = enabled,
+                selectedTabIndexProvider = selectedTabIndexProvider,
+                selectedTabOffset = selectedTabOffset,
+                onTabClicked = onTabClicked,
+                minSpacingDp = minSpacingDp,
+                scrollState = scrollState,
+                indicatorEnabled = indicatorEnabled,
+                interactionSource = interactionSource,
+                tabSizes = tabSizes,
+                tabs = tabs,
+                onTabsMeasured = onTabsMeasured,
+                onScrollControlsVisibilityChange = onScrollControlsVisibilityChange,
+            )
+        } else {
+            RegularColumn(
+                style = style,
+                enabled = enabled,
+                selectedTabIndexProvider = selectedTabIndexProvider,
+                selectedTabOffset = selectedTabOffset,
+                onTabClicked = onTabClicked,
+                clip = clip,
+                spacingDp = spacingDp,
+                canStretch = canStretch,
+                scrollState = scrollState,
+                indicatorEnabled = indicatorEnabled,
+                interactionSource = interactionSource,
+                tabSizes = tabSizes,
+                tabs = tabs,
+                onTabsMeasured = onTabsMeasured,
+            )
+        }
     }
 }
 
@@ -89,6 +117,7 @@ private fun RegularColumn(
     style: TabsStyle,
     enabled: Boolean,
     selectedTabIndexProvider: () -> Int,
+    selectedTabOffset: () -> Float,
     onTabClicked: ((Int) -> Unit)?,
     clip: TabsClip,
     spacingDp: Dp,
@@ -113,7 +142,7 @@ private fun RegularColumn(
                 spacingDp = spacingDp,
                 tabSizes = tabSizes,
                 selectedTabIndexProvider = selectedTabIndexProvider,
-                selectedTabOffset = { 0f },
+                selectedTabOffset = selectedTabOffset,
                 scrollState = scrollState,
                 orientation = TabsOrientation.Vertical,
                 clip = clip,
@@ -135,10 +164,113 @@ private fun RegularColumn(
 }
 
 @Composable
+private fun AutoStretchScrollableColumn(
+    style: TabsStyle,
+    enabled: Boolean,
+    selectedTabIndexProvider: () -> Int,
+    selectedTabOffset: () -> Float,
+    onTabClicked: ((Int) -> Unit)?,
+    minSpacingDp: Dp,
+    scrollState: ScrollState,
+    indicatorEnabled: Boolean,
+    interactionSource: InteractionSource,
+    tabSizes: SnapshotStateList<Int>,
+    tabs: List<@Composable (() -> Unit)>,
+    onTabsMeasured: (Int, IntSize) -> Unit,
+    onScrollControlsVisibilityChange: ((Boolean) -> Unit)?,
+) {
+    SubcomposeLayout { constraints ->
+        val measureConstraints = constraints.copy(
+            minWidth = 0,
+            maxHeight = Constraints.Infinity,
+            minHeight = 0,
+        )
+        val naturalHeights = subcompose(AutoStretchScrollableColumnSlot.Measure) {
+            tabs.forEach { tabItem ->
+                TabItemContainer(
+                    stretch = false,
+                    enabled = enabled,
+                    onClick = null,
+                    onSizeMeasured = {},
+                    tabItemStyle = style.tabItemStyle,
+                    tabItemContent = tabItem,
+                )
+            }
+        }.map { measurable ->
+            measurable.measure(measureConstraints).height
+        }
+
+        val totalNaturalHeight = naturalHeights.sum() +
+            minSpacingDp.roundToPx() * (naturalHeights.size - 1).coerceAtLeast(0)
+        val canStretchWithoutScroll = totalNaturalHeight <= constraints.maxHeight
+        onScrollControlsVisibilityChange?.invoke(!canStretchWithoutScroll)
+        val effectiveSpacing = if (canStretchWithoutScroll) 0.dp else minSpacingDp
+        val effectiveClip = if (canStretchWithoutScroll) TabsClip.None else TabsClip.Scroll
+
+        val contentPlaceable = subcompose(AutoStretchScrollableColumnSlot.Content) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(effectiveSpacing),
+                modifier = Modifier
+                    .then(
+                        if (canStretchWithoutScroll) {
+                            Modifier.fillMaxHeight()
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .tabIndicator(
+                        indicatorEnabled = indicatorEnabled,
+                        indicatorColor = style.colors.indicatorColor.colorForInteraction(
+                            interactionSource,
+                        ),
+                        indicatorShape = style.indicatorShape,
+                        indicatorThickness = style.dimensions.indicatorThickness,
+                        spacingDp = effectiveSpacing,
+                        tabSizes = tabSizes,
+                        selectedTabIndexProvider = selectedTabIndexProvider,
+                        selectedTabOffset = selectedTabOffset,
+                        scrollState = scrollState,
+                        orientation = TabsOrientation.Vertical,
+                        clip = effectiveClip,
+                    )
+                    .clipModifier(
+                        clip = effectiveClip,
+                        scrollState = scrollState,
+                        enabled = enabled,
+                        canStretch = canStretchWithoutScroll,
+                    ),
+            ) {
+                tabs.forEachIndexed { index, tabItem ->
+                    TabItemContainer(
+                        modifier = if (canStretchWithoutScroll) Modifier.weight(1f) else Modifier,
+                        stretch = canStretchWithoutScroll,
+                        onClick = { onTabClicked?.invoke(index) },
+                        onSizeMeasured = { intSize -> onTabsMeasured.invoke(index, intSize) },
+                        tabItemStyle = style.tabItemStyle,
+                        enabled = enabled,
+                        tabItemContent = tabItem,
+                    )
+                }
+            }
+        }.first().measure(constraints)
+
+        layout(contentPlaceable.width, contentPlaceable.height) {
+            contentPlaceable.placeRelative(0, 0)
+        }
+    }
+}
+
+private enum class AutoStretchScrollableColumnSlot {
+    Measure,
+    Content,
+}
+
+@Composable
 private fun ShowMoreColumn(
     style: TabsStyle,
     enabled: Boolean,
     selectedTabIndexProvider: () -> Int,
+    selectedTabOffset: () -> Float,
     onTabClicked: ((Int) -> Unit)?,
     spacingDp: Dp,
     canStretch: Boolean,
@@ -181,7 +313,7 @@ private fun ShowMoreColumn(
                 spacingDp = spacingDp,
                 tabSizes = tabSizes,
                 selectedTabIndexProvider = selectedTabIndexProvider,
-                selectedTabOffset = { 0f },
+                selectedTabOffset = selectedTabOffset,
                 scrollState = scrollState,
                 orientation = TabsOrientation.Vertical,
                 clip = TabsClip.ShowMore,


### PR DESCRIPTION
## sdds-uikit-compose

### Tabs

-   Tabs могут растягиваться (stretch=true) в режиме clip = TabsClip.Scroll, если суммарный размер табов меньше, чем размер контейнера
-   В TabItem переопределен порядок Modifier. Теперь можно навесить Modifier.combinedClickable для обработки long-click.

### What/why changed
-   Tabs могут растягиваться (stretch=true) в режиме clip = TabsClip.Scroll, если суммарный размер табов меньше, чем размер контейнера
-   В TabItem переопределен порядок Modifier. Теперь можно навесить Modifier.combinedClickable для обработки long-click.