### PR TITLE
PLASMA-7257: fix(sdds-acore/uikit-compose): Icon now supports Color.Unsecified.

### DIFF
--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/graphics/brush/BrushProducer.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/graphics/brush/BrushProducer.kt
@@ -1,6 +1,9 @@
 package com.sdds.compose.uikit.graphics.brush
 
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.isUnspecified
 
 /**
  * Поставщик кисти.
@@ -14,3 +17,21 @@ fun interface BrushProducer {
      */
     operator fun invoke(): Brush
 }
+
+/**
+ * Специальный экземпляр, возвращающий неопределённую (неустановленную) кисть
+ */
+val Brush.Companion.Unspecified: Brush get() = UnspecifiedBrush
+
+/**
+ * Проверяет является ли эта кисть неопределеной
+ */
+val Brush.isUnspecified: Boolean
+    get() = (this == UnspecifiedBrush) || (this as? SolidColor)?.value?.isUnspecified == true
+
+/**
+ * Проверяет является ли эта кисть определенной
+ */
+val Brush.isSpecified: Boolean get() = !isUnspecified
+
+private val UnspecifiedBrush = SolidColor(Color.Unspecified)

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/icon/BaseIcon.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/icon/BaseIcon.kt
@@ -67,7 +67,7 @@ internal fun BaseIcon(
             .defaultSizeFor(sourcePainter, LocalIconDefaultSize.current)
             .graphicsLayer {
                 val brush = brushProducer?.invoke()
-                if (brush?.isSpecified == true && brush is SolidColor) {
+                if (brush?.isSpecified == true && brush !is SolidColor) {
                     compositingStrategy = CompositingStrategy.Offscreen
                 }
             }

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/icon/BaseIcon.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/icon/BaseIcon.kt
@@ -27,6 +27,8 @@ import com.sdds.compose.uikit.ImageSource
 import com.sdds.compose.uikit.LocalIconDefaultSize
 import com.sdds.compose.uikit.LocalTintBrushProducer
 import com.sdds.compose.uikit.graphics.brush.BrushProducer
+import com.sdds.compose.uikit.graphics.brush.isSpecified
+import com.sdds.compose.uikit.graphics.brush.isUnspecified
 
 @Composable
 internal fun BaseIcon(
@@ -49,8 +51,10 @@ internal fun BaseIcon(
         ColorFilterPainter(
             delegate = sourcePainter,
             colorFilterProvider = {
-                when (val brush = brushProducer?.invoke()) {
-                    is SolidColor -> ColorFilter.tint(brush.value)
+                val brush = brushProducer?.invoke()
+                when {
+                    brush == null || brush.isUnspecified -> null
+                    brush is SolidColor -> ColorFilter.tint(brush.value)
                     else -> ColorFilter.tint(Color.Black)
                 }
             },
@@ -62,7 +66,8 @@ internal fun BaseIcon(
             .toolingGraphicsLayer()
             .defaultSizeFor(sourcePainter, LocalIconDefaultSize.current)
             .graphicsLayer {
-                if (brushProducer != null && brushProducer.invoke() !is SolidColor) {
+                val brush = brushProducer?.invoke()
+                if (brush?.isSpecified == true && brush is SolidColor) {
                     compositingStrategy = CompositingStrategy.Offscreen
                 }
             }


### PR DESCRIPTION
## sdds-uikit-compose

### Icon

-   Исправлено поведение при передаче Color.Unspecified. 

### Button

-   Исправлено поведение при передаче Color.Unspecified в качестве цвета иконки кнопки. 


### What/why changed
Исправлено поведение при передаче Color.Unspecified. 