### PR TITLE
chore: api-info modules were ignored for bump

### DIFF
--- a/.ignore-changed-modules
+++ b/.ignore-changed-modules
@@ -1,6 +1,8 @@
 :tokens:plasma.giga.app.compose
 :tokens:stylessalute.compose
 :tokens:stylessalute.view
+:sdds-core:api-info-compose
+:sdds-core:api-info-ksp
 :sdds-core:docs
 :sdds-core:docs-compose
 :sdds-core:docs-ksp


### PR DESCRIPTION
Новые модули api-info добавлены в .ignore-changed-modules