### PR TITLE
feat(sdds-acore/uikit-compose): Bump versions after fixed ModalBottomSheet footer

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ glide = "4.16.0"
 koilVersion-compose = "2.2.0"
 
 sdds-uikit = "0.44.0"
-sdds-uikit-compose = "0.46.0"
+sdds-uikit-compose = "0.46.1"
 sdds-theme-builder = "0.43.0"
 sdds-haze = "0.4.0"
 

--- a/sdds-core/uikit-compose/gradle.properties
+++ b/sdds-core/uikit-compose/gradle.properties
@@ -3,4 +3,4 @@ nexus.snapshot=false
 nexus.description=SDDS UIKit library with base components for android jetpack compose
 versionMajor=0
 versionMinor=46
-versionPatch=0
+versionPatch=1

--- a/tokens/plasma-stards-compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma-stards-compose/docs/override-docs/versionsArchived.json
@@ -24,5 +24,6 @@
   "0.30.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.30.0/",
   "0.31.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.31.0/",
   "0.31.1": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.31.1/",
-  "0.32.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.32.0/"
+  "0.32.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.32.0/",
+  "0.33.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.33.0/"
 }

--- a/tokens/plasma-stards-compose/gradle.properties
+++ b/tokens/plasma-stards-compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-star-ds library for compose framework
 versionMajor=0
 versionMinor=33
-versionPatch=0
+versionPatch=1
 
 theme-url=https://github.com/salute-developers/theme-converter/raw/main/themes/plasma_stards/0.7.0-alpha.zip
 components-version=0.19.0

--- a/tokens/plasma.giga.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma.giga.compose/docs/override-docs/versionsArchived.json
@@ -23,5 +23,6 @@
   "0.28.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.28.0/",
   "0.29.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.29.0/",
   "0.29.1": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.29.1/",
-  "0.30.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.30.0/"
+  "0.30.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.30.0/",
+  "0.31.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.31.0/"
 }

--- a/tokens/plasma.giga.compose/gradle.properties
+++ b/tokens/plasma.giga.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-giga library for compose framework
 versionMajor=0
 versionMinor=31
-versionPatch=0
+versionPatch=1
 
 theme-version=latest
 components-version=0.13.0

--- a/tokens/plasma.homeds.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma.homeds.compose/docs/override-docs/versionsArchived.json
@@ -23,5 +23,6 @@
   "0.20.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.20.0/",
   "0.21.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.21.0/",
   "0.21.1": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.21.1/",
-  "0.22.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.22.0/"
+  "0.22.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.22.0/",
+  "0.23.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.23.0/"
 }

--- a/tokens/plasma.homeds.compose/gradle.properties
+++ b/tokens/plasma.homeds.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-homeds library for compose framework
 versionMajor=0
 versionMinor=23
-versionPatch=0
+versionPatch=1
 
 theme-version=0.3.0
 components-version=0.15.0

--- a/tokens/plasma.sd.service.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma.sd.service.compose/docs/override-docs/versionsArchived.json
@@ -24,5 +24,6 @@
   "0.36.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.36.0/",
   "0.37.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.37.0/",
   "0.37.1": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.37.1/",
-  "0.38.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.38.0/"
+  "0.38.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.38.0/",
+  "0.39.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.39.0/"
 }

--- a/tokens/plasma.sd.service.compose/gradle.properties
+++ b/tokens/plasma.sd.service.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-sd-service library for compose framework
 versionMajor=0
 versionMinor=39
-versionPatch=0
+versionPatch=1
 
 # ?????? plasma_b2c_ACTUAL_TYPOGRAPHY
 theme-version=0.1.0

--- a/tokens/sdds-sbcom-compose/docs/override-docs/versionsArchived.json
+++ b/tokens/sdds-sbcom-compose/docs/override-docs/versionsArchived.json
@@ -6,5 +6,6 @@
   "0.5.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.5.0/",
   "0.6.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.6.0/",
   "0.6.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.6.1/",
-  "0.7.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.7.0/"
+  "0.7.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.7.0/",
+  "0.8.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.8.0/"
 }

--- a/tokens/sdds-sbcom-compose/gradle.properties
+++ b/tokens/sdds-sbcom-compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=sdds sbcom library for compose framework
 versionMajor=0
 versionMinor=8
-versionPatch=0
+versionPatch=1
 
 components-version=0.8.0
 

--- a/tokens/sdds.serv.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/sdds.serv.compose/docs/override-docs/versionsArchived.json
@@ -24,5 +24,6 @@
   "0.35.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.35.0/",
   "0.36.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.36.0/",
   "0.36.1": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.36.1/",
-  "0.37.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.37.0/"
+  "0.37.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.37.0/",
+  "0.38.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.38.0/"
 }

--- a/tokens/sdds.serv.compose/gradle.properties
+++ b/tokens/sdds.serv.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=sdds-serv token library for compose framework
 versionMajor=0
 versionMinor=38
-versionPatch=0
+versionPatch=1
 
 theme-version=0.8.0
 components-version=0.17.0


### PR DESCRIPTION
### What/why changed
Инкремент версий библиотек после исправления бага в ModalBottomSheet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added archived documentation links for several older versions across multiple Compose token libraries.
* **Chores**
  * Bumped patch versions for multiple UI token and core Compose packages.
  * Updated one Compose dependency version to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->