### PR TITLE
PLASMA-7717: fix(sdds-alibs/sdds-sbcom): RippleEffect was fixed for short click events.

### DIFF
--- a/tokens/sdds-sbcom-compose/src/main/kotlin/com/sdds/sbcom/motion/indication/RippleIndication.kt
+++ b/tokens/sdds-sbcom-compose/src/main/kotlin/com/sdds/sbcom/motion/indication/RippleIndication.kt
@@ -353,9 +353,16 @@ private class RippleIndicationNode(
 
     private fun finishRipple() {
         currentPress = null
-        scaleJob?.cancel()
         alphaJob?.cancel()
         alphaJob = coroutineScope.launch {
+            if (alpha.value < 1f) {
+                alpha.animateTo(
+                    targetValue = 1f,
+                    animationSpec = opacityFadeInAnimationSpec,
+                ) {
+                    invalidateDraw()
+                }
+            }
             alpha.animateTo(
                 targetValue = 0f,
                 animationSpec = opacityFadeOutAnimationSpec,


### PR DESCRIPTION

## sdds-sbcom-compose

### Ripple Indication

-   Исправлено поведение ripple индикации при быстрых кликах. 

### What/why changed
При быстрых кликах событие Release отменяло анимацию рипл индикации. Теперь, если анимация альфы Press не была доведена до конца, то при отмене нажатия (Release) мы принудительно доводим ее до конца и только потом проигрываем анимацию отмены рипла. 