### PR TITLE
PLASMA-7748: fix(sdds-alibs/plasma-homeds): NavigationBar back icons were fixed

### DIFF
--- a/build-system/docs-template/compose-template/docs/components/CollapsingNavigationBarUsage.md
+++ b/build-system/docs-template/compose-template/docs/components/CollapsingNavigationBarUsage.md
@@ -12,6 +12,18 @@ title: CollapsingNavigationBar
 
 <!-- @screenshot: com.sdds.compose.uikit.fixtures.samples.collapsingnavigationbar.CollapsingNavigationBar_Simple -->
 
+## Использование с коротким списком
+
+По умолчанию `exitUntilCollapsedScrollBehavior` обрабатывает события вложенного скролла всегда. Поэтому навигационная панель может схлопываться при жесте над списком, даже если все его элементы помещаются во вьюпорте.
+
+Чтобы панель реагировала на скролл только тогда, когда список действительно можно прокрутить, передайте в `canScroll` состояние `LazyColumn`:
+
+```kotlin
+// @sample: com/sdds/compose/uikit/fixtures/samples/collapsingnavigationbar/CollapsingNavigationBar_ShortList.kt
+```
+
+При такой настройке жест над коротким списком не схлопывает панель. При этом панель по-прежнему можно схлопывать и раскрывать жестом непосредственно на ней — это ожидаемое поведение `CollapsingNavigationBar`.
+
 ## Стиль CollapsingNavigationBar
 
 В большинстве случаев можно использовать готовые сгенерированные стили, а при необходимости создать собственный стиль через соответствующий builder. Подробнее о том, как работают `Style`, `StyleBuilder` и stateful-параметры стиля, см. в разделе [Стилизация компонентов](../theme/Styles.md).

--- a/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/samples/collapsingnavigationbar/CollapsingNavigationBarSamples.kt
+++ b/integration-core/uikit-compose-fixtures/src/main/kotlin/com/sdds/compose/uikit/fixtures/samples/collapsingnavigationbar/CollapsingNavigationBarSamples.kt
@@ -3,6 +3,7 @@ package com.sdds.compose.uikit.fixtures.samples.collapsingnavigationbar
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -60,6 +61,38 @@ fun CollapsingNavigationBar_Simple() {
             )
             LazyColumn {
                 items(100) {
+                    Text(modifier = Modifier.padding(32.dp), text = "Label text $it")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@DocSample(needScreenshot = false)
+fun CollapsingNavigationBar_ShortList() {
+    composableCodeSnippet {
+        val listState = rememberLazyListState()
+        val scrollBehavior =
+            CollapsingNavigationBarDefaults.exitUntilCollapsedScrollBehavior(
+                state = rememberCollapsingNavigationBarState(),
+                canScroll = {
+                    listState.canScrollForward || listState.canScrollBackward
+                },
+            )
+
+        Column(
+            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        ) {
+            CollapsingNavigationBar(
+                scrollBehavior = scrollBehavior,
+                collapsedTitle = { Text("Title") },
+                expandedTitle = { Text("Title") },
+            )
+            LazyColumn(
+                state = listState,
+            ) {
+                items(3) {
                     Text(modifier = Modifier.padding(32.dp), text = "Label text $it")
                 }
             }

--- a/tokens/plasma.homeds.compose/src/main/kotlin/com/sdds/plasma/homeds/styles/collapsingnavigationbar/CollapsingNavigationBarInternalPageStyles.kt
+++ b/tokens/plasma.homeds.compose/src/main/kotlin/com/sdds/plasma/homeds/styles/collapsingnavigationbar/CollapsingNavigationBarInternalPageStyles.kt
@@ -55,7 +55,7 @@ public val CollapsingNavigationBarInternalPage.Default:
                     to PlasmaHomeDsTheme.typography.bodyXsNormal,
             ),
         )
-        .backIcon(com.sdds.icons.R.drawable.ic_disclosure_left_outline_24)
+        .backIcon(com.sdds.icons.R.drawable.ic_chevron_left_24)
         .actionButtonStyle(IconButton.S.Secondary.style())
         .colors {
             backgroundColor(PlasmaHomeDsTheme.colors.surfaceDefaultClear.asStatefulValue())

--- a/tokens/plasma.homeds.compose/src/main/kotlin/com/sdds/plasma/homeds/styles/navigationbar/NavigationBarInternalPageStyles.kt
+++ b/tokens/plasma.homeds.compose/src/main/kotlin/com/sdds/plasma/homeds/styles/navigationbar/NavigationBarInternalPageStyles.kt
@@ -56,7 +56,7 @@ public val NavigationBarInternalPage.Default: WrapperNavigationBarInternalPageDe
                     to PlasmaHomeDsTheme.typography.bodyXsNormal,
             ),
         )
-        .backIcon(com.sdds.icons.R.drawable.ic_disclosure_left_outline_24)
+        .backIcon(com.sdds.icons.R.drawable.ic_chevron_left_24)
         .actionButtonStyle(IconButton.S.Secondary.style())
         .colors {
             backgroundColor(PlasmaHomeDsTheme.colors.surfaceDefaultClear.asInteractive())


### PR DESCRIPTION
## plasma-homeds-compose

### CollapsingNavigationBar, NavigationBar

-  Заменена иконка кнопки назад (disclosure.left.outline.24 -> chevron.left.24)

### What/why changed

В CollapsingNavigationBar, NavigationBar заменена иконка кнопки назад (disclosure.left.outline.24 -> chevron.left.24). Дополнена документация.