### PR TITLE
PLASMA-7762: fix(sdds-acore/uikit-compose): ModalBottomSheet footer clipping was fixed.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ glide = "4.16.0"
 koilVersion-compose = "2.2.0"
 
 sdds-uikit = "0.45.0"
-sdds-uikit-compose = "0.47.0"
+sdds-uikit-compose = "0.47.1"
 sdds-theme-builder = "0.44.0"
 sdds-haze = "0.4.0"
 

--- a/sdds-core/uikit-compose/gradle.properties
+++ b/sdds-core/uikit-compose/gradle.properties
@@ -3,4 +3,4 @@ nexus.snapshot=false
 nexus.description=SDDS UIKit library with base components for android jetpack compose
 versionMajor=0
 versionMinor=47
-versionPatch=0
+versionPatch=1

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/ModalBottomSheet.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/ModalBottomSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -24,6 +25,7 @@ import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
 import com.sdds.compose.uikit.graphics.backgroundBrush
 import com.sdds.compose.uikit.interactions.getValueAsState
@@ -224,7 +226,6 @@ fun ModalBottomSheet(
                 progressProvider = { (sheetState.progressFromHalfExpandedToExpanded) },
                 handlePlacement = handlePlacement,
             )
-            .clip(newShape)
             .backgroundBrush(
                 { backgroundColor.value },
                 newShape,
@@ -247,10 +248,14 @@ fun ModalBottomSheet(
             measurePolicy = measurePolicy,
             content = {
                 header?.let {
+                    val headerClipShape = remember(topShape) {
+                        topShape.copy(bottomStart = CornerSize(0.dp), bottomEnd = CornerSize(0.dp))
+                    }
                     Box(
                         modifier = Modifier
                             .layoutId(HEADER)
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .clip(headerClipShape),
                         contentAlignment = Alignment.Center,
                     ) {
                         header()
@@ -265,6 +270,9 @@ fun ModalBottomSheet(
                     body()
                 }
                 footer?.let {
+                    val footerClipShape = remember(bottomShape) {
+                        bottomShape.copy(topStart = CornerSize(0.dp), topEnd = CornerSize(0.dp))
+                    }
                     Box(
                         modifier = Modifier
                             .layoutId(FOOTER)
@@ -275,12 +283,10 @@ fun ModalBottomSheet(
                                     translationY = layoutState.footerTranslation(
                                         sheetTop = sheetState.requireOffset(),
                                         expandedTop = anchors.minPosition(),
-                                        hiddenTop = anchors.positionOf(Hidden),
-                                        topPadding = top.roundToPx(),
-                                        bottomPadding = bottom.roundToPx(),
                                     )
                                 }
-                            },
+                            }
+                            .clip(footerClipShape),
                         contentAlignment = Alignment.Center,
                     ) {
                         footer()
@@ -388,21 +394,11 @@ private class BottomSheetLayoutState {
     fun footerTranslation(
         sheetTop: Float,
         expandedTop: Float,
-        hiddenTop: Float,
-        topPadding: Int,
-        bottomPadding: Int,
     ): Float {
         // максимальное смещение, после которого footer начинает двигаться вместе с BottomSheet
         val maxTranslation = (layoutHeight - footerHeight).toFloat()
-        // позиция верхней границы footer на экране, когда BottomSheet раскрыт
-        val footerTopWhenExpanded = expandedTop + maxTranslation
-        // позиция, в котрой footer должен быть зафиксирован
-        val desireFooterTop = hiddenTop - footerHeight - topPadding - bottomPadding
-        // базовая компенсация, необходимая для фиксации footer
-        val baseTranslation = desireFooterTop - footerTopWhenExpanded
-        // на сколько BottomSheet сместился относительно expanded
-        val dragDelta = sheetTop - expandedTop
-        return (baseTranslation - dragDelta).coerceIn(-maxTranslation, baseTranslation)
+        // компенсируем смещение BottomSheet от Expanded, где footer остается без translation
+        return -(sheetTop - expandedTop).coerceIn(0f, maxTranslation)
     }
 }
 

--- a/tokens/sdds-sbcom-compose/docs/override-docs/versionsArchived.json
+++ b/tokens/sdds-sbcom-compose/docs/override-docs/versionsArchived.json
@@ -8,5 +8,6 @@
   "0.6.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.6.1/",
   "0.7.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.7.0/",
   "0.8.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.8.0/",
-  "0.8.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.8.1/"
+  "0.8.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.8.1/",
+  "0.9.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.9.0/"
 }

--- a/tokens/sdds-sbcom-compose/gradle.properties
+++ b/tokens/sdds-sbcom-compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=sdds sbcom library for compose framework
 versionMajor=0
 versionMinor=9
-versionPatch=0
+versionPatch=1
 
 components-version=0.8.0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal bottom sheet corner rendering by applying rounded corners correctly to the header and footer.
  - Refined footer animation positioning for smoother, more consistent movement across sheet states.

- **Documentation**
  - Updated archived version records to include the latest token package release.

- **Chores**
  - Updated package versions to the latest patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->