### PR TITLE
PLASMA-7846: fix(sdds-acore/uikit-compose): Collapsing NavBar insets were fixed

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ glide = "4.16.0"
 koilVersion-compose = "2.2.0"
 
 sdds-uikit = "0.46.0"
-sdds-uikit-compose = "0.48.0"
+sdds-uikit-compose = "0.48.1"
 sdds-theme-builder = "0.45.0"
 sdds-haze = "0.4.0"
 

--- a/sdds-core/uikit-compose/gradle.properties
+++ b/sdds-core/uikit-compose/gradle.properties
@@ -3,4 +3,4 @@ nexus.snapshot=false
 nexus.description=SDDS UIKit library with base components for android jetpack compose
 versionMajor=0
 versionMinor=48
-versionPatch=0
+versionPatch=1

--- a/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/navigationbar/BaseCollapsingNavigationBar.kt
+++ b/sdds-core/uikit-compose/src/main/kotlin/com/sdds/compose/uikit/internal/navigationbar/BaseCollapsingNavigationBar.kt
@@ -144,12 +144,16 @@ internal fun BaseCollapsingNavBar(
                 progress = appBarBackgroundProgress,
             ),
     ) {
-        Box {
+        Box(
+            modifier = Modifier.windowInsetsPadding(
+                windowInsets.only(WindowInsetsSides.Top),
+            ),
+        ) {
             // Верхний контент
             CollapsingNavBarLayout(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .windowInsetsPadding(windowInsets)
+                    .windowInsetsPadding(windowInsets.only(WindowInsetsSides.Horizontal))
                     .clipToBounds(),
                 offsetPx = { 0f },
                 alpha = { collapsedAlpha },

--- a/tokens/plasma-stards-compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma-stards-compose/docs/override-docs/versionsArchived.json
@@ -27,5 +27,7 @@
   "0.32.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.32.0/",
   "0.33.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.33.0/",
   "0.33.1": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.33.1/",
-  "0.34.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.34.0/"
+  "0.34.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.34.0/",
+  "0.35.0": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.35.0/",
+  "0.35.1": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.35.1/"
 }

--- a/tokens/plasma-stards-compose/gradle.properties
+++ b/tokens/plasma-stards-compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-star-ds library for compose framework
 versionMajor=0
 versionMinor=35
-versionPatch=0
+versionPatch=1
 
 theme-url=https://github.com/salute-developers/theme-converter/raw/main/themes/plasma_stards/0.7.0-alpha.zip
 components-version=0.19.0

--- a/tokens/plasma.giga.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma.giga.compose/docs/override-docs/versionsArchived.json
@@ -26,5 +26,8 @@
   "0.30.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.30.0/",
   "0.31.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.31.0/",
   "0.31.1": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.31.1/",
-  "0.32.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.32.0/"
+  "0.32.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.32.0/",
+  "0.32.1": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.32.1/",
+  "0.33.0": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.33.0/",
+  "0.33.1": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.33.1/"
 }

--- a/tokens/plasma.giga.compose/gradle.properties
+++ b/tokens/plasma.giga.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-giga library for compose framework
 versionMajor=0
 versionMinor=33
-versionPatch=0
+versionPatch=1
 
 theme-version=latest
 components-version=0.13.0

--- a/tokens/plasma.homeds.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma.homeds.compose/docs/override-docs/versionsArchived.json
@@ -26,5 +26,7 @@
   "0.22.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.22.0/",
   "0.23.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.23.0/",
   "0.23.1": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.23.1/",
-  "0.24.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.24.0/"
+  "0.24.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.24.0/",
+  "0.25.0": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.25.0/",
+  "0.25.1": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.25.1/"
 }

--- a/tokens/plasma.homeds.compose/gradle.properties
+++ b/tokens/plasma.homeds.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-homeds library for compose framework
 versionMajor=0
 versionMinor=25
-versionPatch=0
+versionPatch=1
 
 theme-version=0.4.0
 components-version=0.16.0

--- a/tokens/plasma.sd.service.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/plasma.sd.service.compose/docs/override-docs/versionsArchived.json
@@ -27,5 +27,7 @@
   "0.38.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.38.0/",
   "0.39.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.39.0/",
   "0.39.1": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.39.1/",
-  "0.40.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.40.0/"
+  "0.40.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.40.0/",
+  "0.41.0": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.41.0/",
+  "0.41.1": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.41.1/"
 }

--- a/tokens/plasma.sd.service.compose/gradle.properties
+++ b/tokens/plasma.sd.service.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=plasma-sd-service library for compose framework
 versionMajor=0
 versionMinor=41
-versionPatch=0
+versionPatch=1
 
 # ?????? plasma_b2c_ACTUAL_TYPOGRAPHY
 theme-version=0.2.0

--- a/tokens/sdds-sbcom-compose/docs/override-docs/versionsArchived.json
+++ b/tokens/sdds-sbcom-compose/docs/override-docs/versionsArchived.json
@@ -10,5 +10,7 @@
   "0.8.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.8.0/",
   "0.8.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.8.1/",
   "0.9.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.9.0/",
-  "0.9.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.9.1/"
+  "0.9.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.9.1/",
+  "0.10.0": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.10.0/",
+  "0.10.1": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.10.1/"
 }

--- a/tokens/sdds-sbcom-compose/gradle.properties
+++ b/tokens/sdds-sbcom-compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=sdds sbcom library for compose framework
 versionMajor=0
 versionMinor=10
-versionPatch=0
+versionPatch=1
 
 components-version=0.8.0
 

--- a/tokens/sdds.serv.compose/docs/override-docs/versionsArchived.json
+++ b/tokens/sdds.serv.compose/docs/override-docs/versionsArchived.json
@@ -27,5 +27,7 @@
   "0.37.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.37.0/",
   "0.38.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.38.0/",
   "0.38.1": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.38.1/",
-  "0.39.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.39.0/"
+  "0.39.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.39.0/",
+  "0.40.0": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.40.0/",
+  "0.40.1": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.40.1/"
 }

--- a/tokens/sdds.serv.compose/gradle.properties
+++ b/tokens/sdds.serv.compose/gradle.properties
@@ -3,7 +3,7 @@ nexus.snapshot=false
 nexus.description=sdds-serv token library for compose framework
 versionMajor=0
 versionMinor=40
-versionPatch=0
+versionPatch=1
 
 theme-version=0.9.0
 components-version=0.17.0


### PR DESCRIPTION
### sdds-uikit-compose

## CollapsingNavigationBar 

- Исправлена проблема с инсетами в CollapsingNavigationBar


### What/why changed

Исправлена проблема с инсетами в CollapsingNavigationBar

| Было | Стало |
|--------|--------|
| [Screen_recording_20260723_155753.webm](https://github.com/user-attachments/assets/394e1304-a04b-4ab1-bdfd-61889fcec0ee) | [Screen_recording_20260723_154621.webm](https://github.com/user-attachments/assets/aa938aa7-0ffe-4284-bc2c-32cab812b46f)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsing navigation bar layout behavior by applying top and horizontal system insets separately, preventing incorrect spacing.

* **Documentation**
  * Added archived documentation links for newer Compose library versions across supported design-system packages.

* **Chores**
  * Bumped patch versions for Compose UI kit and related theme libraries to release updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->