### PR TITLE
PLASMA-7887: fix(sdds-acore/uikit-compose): Wheel performance was improved

### DIFF
--- a/integration-core/uikit-compose-fixtures/src/commonMain/kotlin/com/sdds/compose/uikit/fixtures/stories/wheel/WheelStory.kt
+++ b/integration-core/uikit-compose-fixtures/src/commonMain/kotlin/com/sdds/compose/uikit/fixtures/stories/wheel/WheelStory.kt
@@ -2,9 +2,14 @@ package com.sdds.compose.uikit.fixtures.stories.wheel
 
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import com.sdds.compose.sandbox.ComposeBaseStory
+import com.sdds.compose.uikit.Button
+import com.sdds.compose.uikit.ModalBottomSheet
 import com.sdds.compose.uikit.Wheel
 import com.sdds.compose.uikit.WheelDataSet
 import com.sdds.compose.uikit.WheelItemData
@@ -12,10 +17,13 @@ import com.sdds.compose.uikit.WheelSeparator
 import com.sdds.compose.uikit.WheelStyle
 import com.sdds.compose.uikit.fixtures.stories.WheelUiStatePropertiesProducer
 import com.sdds.compose.uikit.fixtures.stories.WheelUiStateTransformer
+import com.sdds.compose.uikit.internal.modal.BottomSheetValue
+import com.sdds.compose.uikit.internal.modal.rememberModalBottomSheetState
 import com.sdds.sandbox.ComponentKey
 import com.sdds.sandbox.Story
 import com.sdds.sandbox.StoryUiState
 import com.sdds.sandbox.UiState
+import kotlinx.coroutines.launch
 
 /**
  * Состояние компонента [Wheel].
@@ -29,6 +37,9 @@ import com.sdds.sandbox.UiState
  * @property wheelCount Количество колес.
  * @property visibleItemsCount Количество видимых элементов.
  * @property separatorType Тип разделителя между элементами.
+ * @property itemsCount Количество элементов в каждом колесе.
+ * @property initialIndex Индекс изначально выбранного элемента.
+ * @property inBottomSheet Показывать колесо в ModalBottomSheet.
  */
 @StoryUiState
 data class WheelUiState(
@@ -42,6 +53,9 @@ data class WheelUiState(
     val visibleItemsCount: Int = 3,
     val separatorType: WheelSeparator = WheelSeparator.Dots,
     val fillMaxWidth: Boolean = true,
+    val itemsCount: Int = 30,
+    val initialIndex: Int = 0,
+    val inBottomSheet: Boolean = false,
 ) : UiState {
 
     override fun updateVariant(appearance: String, variant: String): UiState {
@@ -61,27 +75,29 @@ object WheelStory : ComposeBaseStory<WheelUiState, WheelStyle>(
         style: WheelStyle,
         state: WheelUiState,
     ) {
-        Wheel(
-            modifier = if (state.fillMaxWidth) Modifier.fillMaxWidth() else Modifier,
-            style = style,
-            hasControls = state.hasControls,
-            wheelCount = state.wheelCount,
-            visibleItemsCount = state.visibleItemsCount,
-            wheelSeparator = state.separatorType,
-            onItemSelected = { wheelIndex, itemIndex ->
-                println("item selected: $itemIndex in wheel $wheelIndex")
-            },
-        ) { wheelIndex ->
-            WheelDataSet(
-                dataSet = List(30) {
-                    WheelItemData(
-                        text = "${state.itemLabel}$it",
-                        textAfter = state.textAfter,
-                    )
-                },
-                description = state.description,
-                staticTextAfter = state.textAfter,
+        if (state.inBottomSheet) {
+            val sheetState = rememberModalBottomSheetState(
+                initialValue = BottomSheetValue.Hidden,
+                skipHalfExpanded = true,
             )
+            val scope = rememberCoroutineScope()
+            Button(
+                label = "показать Wheel в BottomSheet",
+                onClick = { scope.launch { sheetState.show() } },
+            )
+            ModalBottomSheet(
+                modifier = Modifier.statusBarsPadding(),
+                sheetState = sheetState,
+                fitContent = true,
+            ) {
+                WheelContent(
+                    style = style,
+                    state = state,
+                    modifier = Modifier.navigationBarsPadding(),
+                )
+            }
+        } else {
+            WheelContent(style = style, state = state)
         }
     }
 
@@ -103,5 +119,36 @@ object WheelStory : ComposeBaseStory<WheelUiState, WheelStyle>(
                 },
             )
         }
+    }
+}
+
+@Composable
+private fun WheelContent(
+    style: WheelStyle,
+    state: WheelUiState,
+    modifier: Modifier = Modifier,
+) {
+    Wheel(
+        modifier = modifier.then(if (state.fillMaxWidth) Modifier.fillMaxWidth() else Modifier),
+        style = style,
+        hasControls = state.hasControls,
+        wheelCount = state.wheelCount,
+        visibleItemsCount = state.visibleItemsCount,
+        wheelSeparator = state.separatorType,
+        onItemSelected = { wheelIndex, itemIndex ->
+            println("item selected: $itemIndex in wheel $wheelIndex")
+        },
+    ) {
+        WheelDataSet(
+            dataSet = List(state.itemsCount) {
+                WheelItemData(
+                    text = "${state.itemLabel}$it",
+                    textAfter = state.textAfter,
+                )
+            },
+            initialIndex = state.initialIndex.coerceIn(0, (state.itemsCount - 1).coerceAtLeast(0)),
+            description = state.description,
+            staticTextAfter = state.textAfter,
+        )
     }
 }

--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/Wheel.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/Wheel.kt
@@ -131,7 +131,7 @@ fun Wheel(
                 separatorColor = separatorColor,
                 textMeasurer = textMeasurer,
                 separatorTextStyle = separatorTextStyle,
-                labelOffsetFromCenter = labelOffsetFromCenter,
+                labelOffsetFromCenter = { labelOffsetFromCenter },
             )
         },
     ) { wheelIndex ->
@@ -298,7 +298,7 @@ private fun WheelSeparatorBox(
     separatorColor: Color,
     textMeasurer: TextMeasurer,
     separatorTextStyle: TextStyle,
-    labelOffsetFromCenter: Float,
+    labelOffsetFromCenter: () -> Float,
 ) {
     Box(
         modifier = Modifier
@@ -370,7 +370,7 @@ private fun Modifier.drawSeparator(
     separatorColor: Color,
     textMeasurer: TextMeasurer,
     separatorTextStyle: TextStyle,
-    labelOffsetFromCenter: Float,
+    labelOffsetFromCenter: () -> Float,
 ): Modifier {
     return drawBehind {
         val separatorCenter = style.dimensions.separatorSpacing.toPx() / 2f
@@ -393,7 +393,7 @@ private fun Modifier.drawSeparator(
                     color = separatorColor,
                     topLeft = Offset(
                         separatorCenter - textLayoutResult.size.width / 2f,
-                        center.y + labelOffsetFromCenter,
+                        center.y + labelOffsetFromCenter(),
                     ),
                 )
             }

--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/wheel/BaseWheel.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/wheel/BaseWheel.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -37,11 +39,14 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.ParagraphIntrinsics
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sdds.compose.uikit.DataEdgePlacement
@@ -57,6 +62,7 @@ import com.sdds.compose.uikit.interactions.asInteractive
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import kotlin.math.ceil
 import kotlin.math.roundToInt
 import kotlin.math.sign
 
@@ -112,18 +118,28 @@ internal fun BaseWheel(
         }
     }
 
-    val textMeasurer = rememberTextMeasurer()
     val maxDistanceFromCenter by remember { derivedStateOf { state.layoutInfo.viewportSize.height / 2f } }
     var itemHeight by remember(visibleItemsCount, description) { mutableIntStateOf(0) }
     var descriptionHeight by remember(description, descriptionStyle) { mutableIntStateOf(0) }
     val staticTextAfterText = remember(items, staticTextAfter) {
         staticTextAfter ?: items.firstOrNull { it.textAfter.isNotEmpty() }?.textAfter
     }
+    val textMetrics = rememberWheelTextMetrics(
+        items = items,
+        extendedItems = extendedList,
+        textStyle = textStyle,
+        textAfterStyle = textAfterStyle,
+        textAfterMode = textAfterMode,
+        textAfterPadding = textAfterPadding,
+        staticTextAfter = staticTextAfterText,
+    )
     val scaledWheelHeight = rememberCalculatedWheelHeight(itemHeight, descriptionHeight, visibleItemsCount)
     val labelOffsetFromCenter =
         calculateLabelOffset(scaledWheelHeight, itemHeight, itemSpacing.toPx())
-    onLabelPositionCalculated?.invoke(labelOffsetFromCenter)
-    onItemHeightCalculated?.invoke(itemHeight)
+    SideEffect {
+        onLabelPositionCalculated?.invoke(labelOffsetFromCenter)
+        onItemHeightCalculated?.invoke(itemHeight)
+    }
 
     SubcomposeLayout(
         modifier = modifier,
@@ -146,14 +162,13 @@ internal fun BaseWheel(
         fun measureItemProbe(): WheelItemProbe {
             if (extendedList.isEmpty()) return WheelItemProbe()
 
-            val mostWideItem = findMostWideItem(
-                items = extendedList,
-                textAfterMode = textAfterMode,
-                textAfterPadding = textAfterPadding.roundToPx(),
-                textStyle = textStyle,
-                textAfterStyle = textAfterStyle,
-                measureText = { text, style -> textMeasurer.measure(text, style).size.width },
-            )
+            // Если ширина колеса задана снаружи, probe нужен только ради высоты ячейки,
+            // а она одинакова у всех элементов - самый широкий искать не нужно.
+            val mostWideItem = if (constraints.hasFixedWidth) {
+                textMetrics.heightProbeItem
+            } else {
+                textMetrics.widestItem
+            }
             val placeable = subcompose(WheelSubcomposeSlot.ItemProbe) {
                 Item(
                     title = mostWideItem.text,
@@ -326,19 +341,8 @@ internal fun BaseWheel(
             itemHeight = itemProbe.height
         }
 
-        val staticTextAfterWidthPx = staticTextAfterText
-            ?.takeIf { textAfterMode == TextAfterMode.Static && it.isNotEmpty() }
-            ?.let { textMeasurer.measure(it, textAfterStyle).size.width }
-            ?: 0
-        val maxItemTextWidthPx = if (textAfterMode == TextAfterMode.Static) {
-            calculateMaxItemTextWidth(
-                items = items,
-                textStyle = textStyle,
-                measureText = { text, style -> textMeasurer.measure(text, style).size.width },
-            )
-        } else {
-            0
-        }
+        val staticTextAfterWidthPx = textMetrics.staticTextAfterWidth
+        val maxItemTextWidthPx = textMetrics.maxItemTextWidth
         val staticEndPaddingDp = calculateStaticEndPadding(
             staticTextAfterWidth = staticTextAfterWidthPx,
             textAfterPadding = textAfterPadding.roundToPx(),
@@ -492,37 +496,147 @@ private fun Constraints.unconstrainedMin(): Constraints =
         minHeight = 0,
     )
 
-private fun findMostWideItem(
-    items: List<WheelItemData>,
-    textAfterMode: TextAfterMode,
-    textAfterPadding: Int,
-    textStyle: TextStyle,
-    textAfterStyle: TextStyle,
-    measureText: (String, TextStyle) -> Int,
-): WheelItemData {
-    return if (textAfterMode == TextAfterMode.Static) {
-        items.maxBy { data ->
-            measureText(data.text, textStyle)
+/**
+ * Метрики текста, определяющие ширину колеса.
+ *
+ * @property widestItem самый широкий элемент, по нему измеряется размер ячейки
+ * @property maxItemTextWidth максимальная ширина основного текста ([TextAfterMode.Static])
+ * @property staticTextAfterWidth ширина статичного дополнительного текста ([TextAfterMode.Static])
+ */
+@Stable
+private class WheelTextMetrics(
+    private val items: List<WheelItemData>,
+    private val extendedItems: List<WheelItemData>,
+    private val textStyle: TextStyle,
+    private val textAfterStyle: TextStyle,
+    private val textAfterMode: TextAfterMode,
+    private val textAfterPaddingPx: Int,
+    private val staticTextAfter: String?,
+    private val density: Density,
+    private val fontFamilyResolver: FontFamily.Resolver,
+) {
+    private val titleWidths = HashMap<String, Int>()
+    private val textAfterWidths = HashMap<String, Int>()
+    private val isStaticTextAfter: Boolean get() = textAfterMode == TextAfterMode.Static
+
+    /**
+     * Самый широкий элемент, по нему измеряется размер ячейки.
+     * Обход всего набора данных - самая дорогая часть измерения, поэтому он ленивый:
+     * при фиксированной ширине колеса самый широкий элемент не нужен.
+     */
+    val widestItem: WheelItemData by lazy(LazyThreadSafetyMode.NONE) {
+        extendedItems.maxByOrNull { data ->
+            if (isStaticTextAfter) {
+                titleWidth(data.text)
+            } else {
+                titleWidth(data.text) +
+                    textAfterWidth(data.textAfter) +
+                    if (data.text.isNotEmpty() && data.textAfter.isNotEmpty()) {
+                        textAfterPaddingPx
+                    } else {
+                        0
+                    }
+            }
+        } ?: WheelItemData()
+    }
+
+    /**
+     * Элемент для измерения только высоты ячейки: она одинакова у всех элементов,
+     * важно лишь наличие обеих строк текста.
+     */
+    val heightProbeItem: WheelItemData by lazy(LazyThreadSafetyMode.NONE) {
+        WheelItemData(
+            text = extendedItems.firstOrNull { it.text.isNotEmpty() }?.text.orEmpty(),
+            textAfter = extendedItems.firstOrNull { it.textAfter.isNotEmpty() }?.textAfter.orEmpty(),
+        )
+    }
+
+    /**
+     * Максимальная ширина основного текста, нужна для позиционирования
+     * статичного дополнительного текста ([TextAfterMode.Static]).
+     */
+    val maxItemTextWidth: Int by lazy(LazyThreadSafetyMode.NONE) {
+        if (isStaticTextAfter) items.maxOfOrNull { data -> titleWidth(data.text) } ?: 0 else 0
+    }
+
+    /**
+     * Ширина статичного дополнительного текста ([TextAfterMode.Static]).
+     */
+    val staticTextAfterWidth: Int by lazy(LazyThreadSafetyMode.NONE) {
+        if (isStaticTextAfter && !staticTextAfter.isNullOrEmpty()) {
+            textAfterWidth(staticTextAfter)
+        } else {
+            0
         }
-    } else {
-        items.maxBy { data ->
-            measureText(data.text, textStyle) +
-                measureText(data.textAfter, textAfterStyle) +
-                if (data.text.isNotEmpty() && data.textAfter.isNotEmpty()) {
-                    textAfterPadding
-                } else {
-                    0
-                }
-        }
+    }
+
+    private fun titleWidth(text: String): Int = titleWidths.getOrPut(text) {
+        text.intrinsicWidth(textStyle, density, fontFamilyResolver)
+    }
+
+    private fun textAfterWidth(text: String): Int = textAfterWidths.getOrPut(text) {
+        text.intrinsicWidth(textAfterStyle, density, fontFamilyResolver)
     }
 }
 
-private fun calculateMaxItemTextWidth(
+/**
+ * Считает метрики текста один раз на набор данных, а не на каждый проход измерения.
+ */
+@Composable
+private fun rememberWheelTextMetrics(
     items: List<WheelItemData>,
+    extendedItems: List<WheelItemData>,
     textStyle: TextStyle,
-    measureText: (String, TextStyle) -> Int,
+    textAfterStyle: TextStyle,
+    textAfterMode: TextAfterMode,
+    textAfterPadding: Dp,
+    staticTextAfter: String?,
+): WheelTextMetrics {
+    val density = LocalDensity.current
+    val fontFamilyResolver = LocalFontFamilyResolver.current
+    return remember(
+        items,
+        extendedItems,
+        textStyle,
+        textAfterStyle,
+        textAfterMode,
+        textAfterPadding,
+        staticTextAfter,
+        density,
+        fontFamilyResolver,
+    ) {
+        WheelTextMetrics(
+            items = items,
+            extendedItems = extendedItems,
+            textStyle = textStyle,
+            textAfterStyle = textAfterStyle,
+            textAfterMode = textAfterMode,
+            textAfterPaddingPx = with(density) { textAfterPadding.roundToPx() },
+            staticTextAfter = staticTextAfter,
+            density = density,
+            fontFamilyResolver = fontFamilyResolver,
+        )
+    }
+}
+
+/**
+ * Ширина текста без построения полного layout: для сравнения элементов между собой
+ * достаточно intrinsic-ширины, а точные размеры ячейки дальше измеряет probe.
+ */
+private fun String.intrinsicWidth(
+    style: TextStyle,
+    density: Density,
+    fontFamilyResolver: FontFamily.Resolver,
 ): Int {
-    return items.maxOfOrNull { data -> measureText(data.text, textStyle) } ?: 0
+    if (isEmpty()) return 0
+    val intrinsics = ParagraphIntrinsics(
+        text = this,
+        style = style,
+        annotations = emptyList(),
+        density = density,
+        fontFamilyResolver = fontFamilyResolver,
+    )
+    return ceil(intrinsics.maxIntrinsicWidth).toInt()
 }
 
 private fun calculateStaticEndPadding(
@@ -660,11 +774,6 @@ private fun rememberExtendedList(
             DataEdgePlacement.WheelCenter -> dummyItems + items + dummyItems
         }
     }
-}
-
-@Composable
-private fun rememberMostWideItem(items: List<WheelItemData>): WheelItemData = remember(items) {
-    items.maxBy { it.text.length + it.textAfter.length }
 }
 
 @Composable

--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/wheel/BaseWheel.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/wheel/BaseWheel.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -59,7 +60,7 @@ import com.sdds.compose.uikit.graphics.LocalIndication
 import com.sdds.compose.uikit.graphics.brush.BrushProducer
 import com.sdds.compose.uikit.interactions.InteractiveColor
 import com.sdds.compose.uikit.interactions.asInteractive
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.ceil
@@ -104,6 +105,27 @@ internal fun BaseWheel(
     val state: LazyListState = rememberLazyListState(initialIndex)
     val middleIndex = visibleItemsCount / 2
     val extendedList = rememberExtendedList(items, dataEdgePlacement, middleIndex)
+    val maxFirstVisibleItemIndex = (extendedList.size - visibleItemsCount).coerceAtLeast(0)
+    var controlTargetIndex by remember(initialIndex, maxFirstVisibleItemIndex) {
+        mutableIntStateOf(initialIndex.coerceIn(0, maxFirstVisibleItemIndex))
+    }
+    var controlScrollJob by remember { mutableStateOf<Job?>(null) }
+
+    fun scrollByControl(delta: Int) {
+        val isControlScrollInProgress = controlScrollJob?.isActive == true
+        val currentIndex = if (isControlScrollInProgress) {
+            controlTargetIndex
+        } else {
+            state.firstVisibleItemIndex
+        }
+        val targetIndex = (currentIndex + delta).coerceIn(0, maxFirstVisibleItemIndex)
+        if (targetIndex == currentIndex) return
+
+        controlTargetIndex = targetIndex
+        controlScrollJob = coroutineScope.launch {
+            state.animateScrollToItem(targetIndex)
+        }
+    }
 
     LaunchedEffect(state.firstVisibleItemIndex) {
         val selectedIndex = state.firstVisibleItemIndex + middleIndex
@@ -372,12 +394,12 @@ internal fun BaseWheel(
         val staticTextAfterPlaceable = measureStaticTextAfter()
         val topControlPlaceable = measureControl(WheelSubcomposeSlot.TopControl, lazyColumnWidth) {
             if (hasControls && iconUp != null && iconDown != null) {
-                TopControl(iconUp, iconUpColor, state, coroutineScope)
+                TopControl(iconUp, iconUpColor) { scrollByControl(-1) }
             }
         }
         val bottomControlPlaceable = measureControl(WheelSubcomposeSlot.BottomControl, lazyColumnWidth) {
             if (hasControls && iconUp != null && iconDown != null) {
-                BottomControl(iconDown, iconDownColor, state, coroutineScope)
+                BottomControl(iconDown, iconDownColor) { scrollByControl(1) }
             }
         }
 
@@ -711,8 +733,7 @@ internal enum class WheelItemAlignment {
 private fun TopControl(
     icon: ImageSource,
     color: InteractiveColor,
-    state: LazyListState,
-    coroutineScope: CoroutineScope,
+    onClick: () -> Unit,
 ) {
     val upInteractionSource = remember { MutableInteractionSource() }
     val iconColor = color.colorForInteraction(upInteractionSource)
@@ -722,13 +743,8 @@ private fun TopControl(
             .clickable(
                 interactionSource = upInteractionSource,
                 indication = LocalIndication.current,
-            ) {
-                coroutineScope.launch {
-                    state.animateScrollToItem(
-                        (state.firstVisibleItemIndex - 1).coerceAtLeast(0),
-                    )
-                }
-            },
+                onClick = onClick,
+            ),
         contentDescription = null,
         source = icon,
         brush = BrushProducer { SolidColor(iconColor) },
@@ -739,8 +755,7 @@ private fun TopControl(
 private fun BottomControl(
     icon: ImageSource,
     color: InteractiveColor,
-    state: LazyListState,
-    coroutineScope: CoroutineScope,
+    onClick: () -> Unit,
 ) {
     val downInteractionSource = remember { MutableInteractionSource() }
     val iconColor = color.colorForInteraction(downInteractionSource)
@@ -750,11 +765,8 @@ private fun BottomControl(
             .clickable(
                 interactionSource = downInteractionSource,
                 indication = LocalIndication.current,
-            ) {
-                coroutineScope.launch {
-                    state.animateScrollToItem((state.firstVisibleItemIndex + 1))
-                }
-            },
+                onClick = onClick,
+            ),
         contentDescription = null,
         source = icon,
         brush = BrushProducer { SolidColor(iconColor) },

--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/mask/PhoneMask.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/mask/PhoneMask.kt
@@ -23,7 +23,7 @@ data class PhoneMask(
 
     override fun preFilterInput(text: String): String {
         return text
-            .filterIndexed { index, char -> char.isDigit() || (index == 0 && char == '-') }
+            .filter { it.isDigit() }
             .take(mask.count { it == '#' })
     }
 
@@ -109,12 +109,16 @@ private class PhoneMaskOffsetMapping(
 ) :
     OffsetMapping {
     override fun originalToTransformed(offset: Int): Int {
-        if (originalText.isEmpty()) return 0
+        // formatWithMask возвращает пустую строку, если в тексте нет цифр
+        if (originalText.none { it.isDigit() }) return 0
+        val digitsBeforeOffset = originalText
+            .take(offset.coerceIn(0, originalText.length))
+            .count { it.isDigit() }
         var cleanChars = 0
         var resultIndex = 0
 
         for (i in mask.indices) {
-            if (cleanChars >= offset) break
+            if (cleanChars >= digitsBeforeOffset) break
 
             when (mask[i]) {
                 '#' -> {
@@ -132,7 +136,7 @@ private class PhoneMaskOffsetMapping(
     override fun transformedToOriginal(offset: Int): Int {
         var cleanChars = 0
 
-        for (i in 0 until offset) {
+        for (i in 0 until offset.coerceAtMost(mask.length)) {
             if (cleanChars >= originalText.length) break
             if (mask[i] == '#') {
                 cleanChars++


### PR DESCRIPTION
## sdds-uikit-compose

### Wheel 

- Исправлена проблема производительности Wheel. 

### MaskedTextField

- Исправлен крэш в PhoneMask при вводе минуса
 
### What/why changed

- Исправлена проблема производительности Wheel. 
 1. Метрики текста вынесены в WheelTextMetrics / rememberWheelTextMetrics — считаются один раз на набор данных, а не на каждый проход измерения.                                                                                                                                                                           
  2. Для выбора кандидата вместо полного TextMeasurer.measure() используется ParagraphIntrinsics.maxIntrinsicWidth (без построения MultiParagraph/StaticLayout). Точные размеры ячейки по-прежнему берутся из probe-измерения реального Item.                                                                               
  3. Ширины дедуплицируются по строке через HashMap.                                                                                                                                                                                                                                                                        
  4. Метрики ленивые: если ширина колеса задана снаружи (constraints.hasFixedWidth, типовой случай fillMaxWidth в шторке), самый широкий элемент не нужен — вместо него используется синтетический heightProbeItem, а O(N)-проход не запускается вовсе.                                                                     
  5. labelOffsetFromCenter передаётся лямбдой и читается в draw-фазе (drawSeparator), колбэки размеров вынесены в SideEffect — убрана лишняя рекомпозиция Wheel с пересборкой набора данных.
- Исправлен крэш в MaskedTextField при вводе минуса

| Было | Стало |
|--------|--------|
|  https://github.com/user-attachments/assets/4e209c67-4805-498a-907e-77714a1a58af | https://github.com/user-attachments/assets/28e380a3-53db-4c93-9f45-c612310ad0da |