### PR TITLE
fix(ci): update Plasma icons dependency setup

### DIFF
--- a/.github/workflows/generate-icons.yml
+++ b/.github/workflows/generate-icons.yml
@@ -41,13 +41,11 @@ jobs:
 
       - name: Install plasma web project deps
         working-directory: ./plasma
-        run: npm ci
+        run: npm run setup:deps:ci
 
       - name: Generate android icons
         working-directory: ./plasma
-        run: |
-          npx lerna bootstrap --scope="@salutejs/plasma-icons" --ignore-scripts
-          npm run generate:android --prefix="packages/plasma-icons"
+        run: npm run generate:android --workspace="@salutejs/plasma-icons"
 
       - name: Bump version
         working-directory: ./current


### PR DESCRIPTION
- теперь установка выполняется через npm run setup:deps:ci;
- удалён несовместимый с Lerna 9 lerna bootstrap;
- генерация запускается через workspace @salutejs/plasma-icons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the icon-generation workflow to use the current dependency setup and Android icon generation commands.
  * Simplified the automated process for generating Android icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->