### PR TITLE
PLASMA-7903: Cutout modifier in Avatar now depends on style parameter

### DIFF
--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/Avatar.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/Avatar.kt
@@ -212,7 +212,7 @@ fun Avatar(
         ProvideCutoutState(cutoutState) {
             Box(
                 modifier = Modifier
-                    .cutoutTarget()
+                    .cutoutTarget(enabled = style.statusCutoutEnabled)
                     .avatar(
                         interactionSource = interactionSource,
                         style = style,
@@ -308,7 +308,7 @@ fun Modifier.avatar(
     action: Painter? = null,
     actionEnabled: Boolean = false,
     placeholder: AvatarPlaceholder? = null,
-    statusCutoutEnabled: Boolean = false,
+    statusCutoutEnabled: Boolean = style.statusCutoutEnabled,
     statusCutoutPadding: Dp = 3.dp,
 ): Modifier = composed {
     val dimensions = style.dimensionValues


### PR DESCRIPTION
## sdds-uikit-compose

### Avatar

- Включения modifier cutoutTarget в компоненте Avatar теперь зависит от значения параметра стиля 

### What/why changed

Включения modifier cutoutTarget в компоненте Avatar теперь зависит от значения параметра statusCutoutEnabled стиля Avatar.