### PR TITLE
PLASMA-7905: Popover trigger position tracking is now optional

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,9 +53,9 @@ glide = "4.16.0"
 koilVersion-compose = "3.2.0"
 ktor-client = "3.1.3"
 
-sdds-uikit = "0.48.1"
-sdds-uikit-compose = "0.50.1"
-sdds-theme-builder = "0.47.1"
+sdds-uikit = "0.49.0"
+sdds-uikit-compose = "0.51.0"
+sdds-theme-builder = "0.48.0"
 sdds-dsbuilder = "0.46.0"
 
 sdds-haze = "0.5.1"

--- a/integration-core/sandbox-compose/gradle.properties
+++ b/integration-core/sandbox-compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=sdds-sandbox-compose
 nexus.snapshot=false
 nexus.description=SDDS base sandbox for Jetpack Compose
 versionMajor=0
-versionMinor=11
-versionPatch=1
+versionMinor=12
+versionPatch=0
 
 components-version=0.13.0
 theme-version=0.8.0

--- a/integration-core/sandbox-core/gradle.properties
+++ b/integration-core/sandbox-core/gradle.properties
@@ -2,5 +2,5 @@ nexus.artifactId=sdds-sandbox-core
 nexus.snapshot=false
 nexus.description=SDDS base sandbox
 versionMajor=0
-versionMinor=11
-versionPatch=1
+versionMinor=12
+versionPatch=0

--- a/integration-core/sandbox-ksp/gradle.properties
+++ b/integration-core/sandbox-ksp/gradle.properties
@@ -2,5 +2,5 @@ nexus.artifactId=sdds-sandbox-ksp
 nexus.snapshot=false
 nexus.description=SDDS sandbox ksp plugin
 versionMajor=0
-versionMinor=11
-versionPatch=1
+versionMinor=12
+versionPatch=0

--- a/integration-core/sandbox-view/gradle.properties
+++ b/integration-core/sandbox-view/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=sdds-sandbox-view
 nexus.snapshot=false
 nexus.description=SDDS base sandbox for android view system
 versionMajor=0
-versionMinor=11
-versionPatch=1
+versionMinor=12
+versionPatch=0
 
 components-version=0.13.0
 theme-version=0.8.0

--- a/integration-core/uikit-compose-fixtures/src/commonMain/kotlin/com/sdds/compose/uikit/fixtures/stories/popover/PopoverStory.kt
+++ b/integration-core/uikit-compose-fixtures/src/commonMain/kotlin/com/sdds/compose/uikit/fixtures/stories/popover/PopoverStory.kt
@@ -1,13 +1,17 @@
 package com.sdds.compose.uikit.fixtures.stories.popover
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -95,43 +99,66 @@ object PopoverStory : ComposeBaseStory<PopoverUiState, PopoverStyle>(
         state: PopoverUiState,
     ) {
         val showPopover = remember { mutableStateOf(false) }
-        val triggerInfo = remember { mutableStateOf(TriggerInfo()) }
-        Button(
-            modifier = Modifier
-                .align(state.triggerPlacement.toAlignment())
-                .popoverTrigger(triggerInfo),
-            label = "show popover",
-            onClick = { showPopover.value = true },
-        )
-        Popover(
-            show = showPopover.value,
-            triggerInfo = triggerInfo.value,
-            safeAreaPadding = PaddingValues(0.dp),
-            placement = state.placement,
-            placementMode = state.placementMode,
-            positionStrategy = state.positionStrategy,
-            triggerCentered = state.triggerCentered,
-            alignment = state.alignment,
-            style = style,
-            tailEnabled = state.tailEnabled,
-            onDismissRequest = {
-                showPopover.value = false
-            },
-            duration = state.autoHide.autoHideToMs(),
+        val activeItemId = remember { mutableStateOf<Int?>(null) }
+        val triggerInfoMap = remember { mutableMapOf<Int, MutableState<TriggerInfo>>() }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(5.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Column(
-                modifier = Modifier
-                    .padding(top = 12.dp, bottom = 8.dp, start = 8.dp, end = 8.dp),
-            ) {
-                Text("Title")
-                Spacer(Modifier.height(4.dp))
-                Text("Text")
-                Spacer(Modifier.height(12.dp))
+            items(1000, key = { it }) { index ->
+                val triggerInfo = triggerInfoMap.getOrPut(index) {
+                    mutableStateOf(TriggerInfo())
+                }
                 Button(
-                    modifier = Modifier.width(166.dp),
-                    label = "Ok",
-                    onClick = { println("Popover" + ": " + "Popover button was pressed") },
+                    modifier = Modifier.popoverTrigger(
+                        triggerInfo = triggerInfo,
+                        enabled = activeItemId.value == index,
+                    ),
+                    label = "Item $index",
+                    onClick = {
+                        activeItemId.value = index
+                        showPopover.value = true
+                    },
                 )
+            }
+        }
+        val currentTriggerInfo = activeItemId.value.let { id ->
+            triggerInfoMap[id]?.value
+        }
+        if (currentTriggerInfo != null) {
+            Popover(
+                show = showPopover.value,
+                triggerInfo = currentTriggerInfo,
+                safeAreaPadding = PaddingValues(0.dp),
+                placement = state.placement,
+                placementMode = state.placementMode,
+                positionStrategy = state.positionStrategy,
+                triggerCentered = state.triggerCentered,
+                alignment = state.alignment,
+                style = style,
+                tailEnabled = state.tailEnabled,
+                onDismissRequest = {
+                    showPopover.value = false
+                    activeItemId.value = null
+                },
+                duration = state.autoHide.autoHideToMs(),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(top = 12.dp, bottom = 8.dp, start = 8.dp, end = 8.dp),
+                ) {
+                    Text("Title")
+                    Spacer(Modifier.height(4.dp))
+                    Text("Text")
+                    Spacer(Modifier.height(12.dp))
+                    Button(
+                        modifier = Modifier.width(166.dp),
+                        label = "Ok",
+                        onClick = { println("Popover" + ": " + "Popover button was pressed") },
+                    )
+                }
             }
         }
     }

--- a/sdds-core/plugin_theme_builder/gradle.properties
+++ b/sdds-core/plugin_theme_builder/gradle.properties
@@ -1,4 +1,4 @@
 versionMajor=0
-versionMinor=47
-versionPatch=1
+versionMinor=48
+versionPatch=0
 nexus.artifactId=sdds-theme-builder

--- a/sdds-core/uikit-compose/gradle.properties
+++ b/sdds-core/uikit-compose/gradle.properties
@@ -2,5 +2,5 @@ nexus.artifactId=sdds-uikit-compose
 nexus.snapshot=false
 nexus.description=SDDS UIKit library with base components for android jetpack compose
 versionMajor=0
-versionMinor=50
-versionPatch=1
+versionMinor=51
+versionPatch=0

--- a/sdds-core/uikit-compose/src/androidMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopoverTrigger.android.kt
+++ b/sdds-core/uikit-compose/src/androidMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopoverTrigger.android.kt
@@ -31,6 +31,7 @@ internal actual fun Modifier.basePopoverTrigger(
     triggerInfo: MutableState<TriggerInfo>,
     shape: Shape,
     cutoutPaddings: PaddingValues,
+    enabled: Boolean,
 ): Modifier {
     return composed {
         val currentScaleFactor = LocalFocusSelectorSettings.current.scale.scaleFactor
@@ -56,41 +57,48 @@ internal actual fun Modifier.basePopoverTrigger(
                 triggerInfo.value = updatedTriggerInfo
             }
         }
-
-        DisposableEffect(hostView.rootView, coordinates) {
-            val listener = ViewTreeObserver.OnPreDrawListener {
-                coordinates?.takeIf { it.isAttached }?.let(::updateTriggerBounds)
-                true
-            }
-            hostView.rootView.viewTreeObserver.addOnPreDrawListener(listener)
-            onDispose {
-                val observer = hostView.rootView.viewTreeObserver
-                if (observer.isAlive) {
-                    observer.removeOnPreDrawListener(listener)
+        if (enabled) {
+            DisposableEffect(hostView.rootView, coordinates) {
+                val listener = ViewTreeObserver.OnPreDrawListener {
+                    coordinates?.takeIf { it.isAttached }?.let(::updateTriggerBounds)
+                    true
+                }
+                hostView.rootView.viewTreeObserver.addOnPreDrawListener(listener)
+                onDispose {
+                    val observer = hostView.rootView.viewTreeObserver
+                    if (observer.isAlive) {
+                        observer.removeOnPreDrawListener(listener)
+                    }
                 }
             }
         }
-        layout { measurable, constraints ->
-            val placeable = measurable.measure(constraints)
-            triggerInfo.value = triggerInfo.value.copy(
-                topAlignmentLine = placeable[topAlignmentLine],
-                bottomAlignmentLine = placeable[bottomAlignmentLine],
-                startAlignmentLine = placeable[startAlignmentLine],
-                endAlignmentLine = placeable[endAlignmentLine],
-            )
-            return@layout layout(placeable.width, placeable.height) {
-                placeable.placeRelative(IntOffset.Zero)
+        if (enabled) {
+            layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                triggerInfo.value = triggerInfo.value.copy(
+                    topAlignmentLine = placeable[topAlignmentLine],
+                    bottomAlignmentLine = placeable[bottomAlignmentLine],
+                    startAlignmentLine = placeable[startAlignmentLine],
+                    endAlignmentLine = placeable[endAlignmentLine],
+                )
+                return@layout layout(placeable.width, placeable.height) {
+                    placeable.placeRelative(IntOffset.Zero)
+                }
             }
-        }.onGloballyPositioned {
-            coordinates = it
-            updateTriggerBounds(it)
-        }.onFocusChanged {
-            val scaleFactor = if (it.isFocused) {
-                currentScaleFactor
-            } else {
-                0f
-            }
-            triggerInfo.value = triggerInfo.value.copy(focusScaleFactor = scaleFactor)
+                .onGloballyPositioned {
+                    coordinates = it
+                    updateTriggerBounds(it)
+                }
+                .onFocusChanged {
+                    val scaleFactor = if (it.isFocused) {
+                        currentScaleFactor
+                    } else {
+                        0f
+                    }
+                    triggerInfo.value = triggerInfo.value.copy(focusScaleFactor = scaleFactor)
+                }
+        } else {
+            Modifier
         }
     }
 }

--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/Popover.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/Popover.kt
@@ -277,8 +277,9 @@ fun Modifier.popoverTrigger(
     triggerInfo: MutableState<TriggerInfo>,
     shape: Shape = RectangleShape,
     cutoutPaddings: PaddingValues = PaddingValues(0.dp),
+    enabled: Boolean = true,
 ): Modifier {
-    return basePopoverTrigger(triggerInfo, shape, cutoutPaddings)
+    return basePopoverTrigger(triggerInfo, shape, cutoutPaddings, enabled)
 }
 
 internal val topAlignmentLine = HorizontalAlignmentLine(merger = { old, new -> max(old, new) })

--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopover.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopover.kt
@@ -108,7 +108,9 @@ internal fun BasePopover(
     val tailPadding = dimensions.tailPadding
     val offset = dimensions.offset
     val visibleState = remember { MutableTransitionState(false) }
-    visibleState.targetState = show
+    val currentTrigger = triggerInfo()
+    val triggerReady = currentTrigger.visibleBoundsInScreen != null
+    visibleState.targetState = show && triggerReady
     val popoverVisible = visibleState.currentState || visibleState.targetState || !visibleState.isIdle
 
     val backgroundColor = colors.backgroundColor.getValue(motion.context.interactionSource)
@@ -131,6 +133,9 @@ internal fun BasePopover(
     val effectiveClipHeight = clipHeight && canClip
     val effectiveClipWidth = clipWidth && canClip
     val keyboardHeightState = getKeyboardHeightPx()
+    var currentPlacement by remember(placement) {
+        mutableStateOf(placement)
+    }
     val positionProvider = rememberPopoverPositionProvider(
         placement = placement,
         placementMode = placementMode,
@@ -159,11 +164,14 @@ internal fun BasePopover(
             }
             constraintsUpdater.request(constraints)
         },
+        onPlacementChange = { newPlacement ->
+            if (currentPlacement != newPlacement) currentPlacement = newPlacement
+        },
     )
     val tailPaddings = tailCompensationPaddings(
         tailEnabled = tailEnabled,
         tailHeight = tailHeight,
-        placement = positionProvider.innerPlacement,
+        placement = currentPlacement,
     )
 
     SideEffect {
@@ -511,6 +519,7 @@ private fun rememberPopoverPositionProvider(
     popoverContentSize: () -> IntSize,
     clippedConstraints: () -> IntSize?,
     onContentSizeChanged: (IntSize) -> Unit,
+    onPlacementChange: (PopoverPlacement) -> Unit,
 ): PopoverPositionProvider {
     // Лямбда не входит в ключи remember: чтение triggerInfo происходит в calculatePosition,
     // где Popup наблюдает snapshot-чтения и сам пересчитывает позицию без рекомпозиции.
@@ -557,6 +566,7 @@ private fun rememberPopoverPositionProvider(
             popoverContentSize,
             clippedConstraints,
             onContentSizeChanged,
+            onPlacementChange,
         )
     }
 }
@@ -584,6 +594,7 @@ private class PopoverPositionProvider(
     private val popoverContentSize: () -> IntSize,
     private val clippedConstraints: () -> IntSize?,
     private val onContentSizeChanged: (IntSize) -> Unit,
+    private val onPlacementChange: (PopoverPlacement) -> Unit,
 ) : PopupPositionProvider {
 
     private var popoverOffsetWhenTriggerCentered: Offset = Offset.Zero
@@ -743,6 +754,7 @@ private class PopoverPositionProvider(
                 tailAlignment = innerTailAlignment,
             )
         }
+        onPlacementChange(innerPlacement)
         lastPositionState = InitialPositionState(
             position = actualPopupPosition,
             placement = innerPlacement,
@@ -755,7 +767,6 @@ private class PopoverPositionProvider(
             availableWindowBounds,
             triggerPositionInRoot,
         )
-
         return actualPopupPosition
     }
 
@@ -1176,7 +1187,6 @@ private class PopoverPositionProvider(
     ): IntOffset {
         val horizontalAlignment = getHorizontalAlignment(triggerSize, popupContentSize)
         val verticalAlignment = getVerticalAlignment(triggerSize, popupContentSize)
-
         return when (innerPlacement) {
             PopoverPlacement.Start -> IntOffset(
                 x = triggerPositionInRoot.x - offset -

--- a/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopoverTrigger.kt
+++ b/sdds-core/uikit-compose/src/commonMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopoverTrigger.kt
@@ -14,6 +14,7 @@ internal expect fun Modifier.basePopoverTrigger(
     triggerInfo: MutableState<TriggerInfo>,
     shape: Shape = RectangleShape,
     cutoutPaddings: PaddingValues = PaddingValues(0.dp),
+    enabled: Boolean,
 ): Modifier
 
 internal fun Rect.toScreenRect(hostLocation: IntArray): Rect {

--- a/sdds-core/uikit-compose/src/skikoMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopoverTrigger.skiko.kt
+++ b/sdds-core/uikit-compose/src/skikoMain/kotlin/com/sdds/compose/uikit/internal/popover/BasePopoverTrigger.skiko.kt
@@ -27,6 +27,7 @@ internal actual fun Modifier.basePopoverTrigger(
     triggerInfo: MutableState<TriggerInfo>,
     shape: Shape,
     cutoutPaddings: PaddingValues,
+    enabled: Boolean,
 ): Modifier {
     return composed {
         val currentScaleFactor = LocalFocusSelectorSettings.current.scale.scaleFactor
@@ -58,27 +59,30 @@ internal actual fun Modifier.basePopoverTrigger(
                 triggerInfo.value = updatedTriggerInfo
             }
         }
-
-        layout { measurable, constraints ->
-            val placeable = measurable.measure(constraints)
-            triggerInfo.value = triggerInfo.value.copy(
-                topAlignmentLine = placeable[topAlignmentLine],
-                bottomAlignmentLine = placeable[bottomAlignmentLine],
-                startAlignmentLine = placeable[startAlignmentLine],
-                endAlignmentLine = placeable[endAlignmentLine],
-            )
-            return@layout layout(placeable.width, placeable.height) {
-                placeable.placeRelative(IntOffset.Zero)
+        if (enabled) {
+            layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                triggerInfo.value = triggerInfo.value.copy(
+                    topAlignmentLine = placeable[topAlignmentLine],
+                    bottomAlignmentLine = placeable[bottomAlignmentLine],
+                    startAlignmentLine = placeable[startAlignmentLine],
+                    endAlignmentLine = placeable[endAlignmentLine],
+                )
+                return@layout layout(placeable.width, placeable.height) {
+                    placeable.placeRelative(IntOffset.Zero)
+                }
+            }.onGloballyPositioned {
+                updateTriggerBounds(it)
+            }.onFocusChanged {
+                val scaleFactor = if (it.isFocused) {
+                    currentScaleFactor
+                } else {
+                    0f
+                }
+                triggerInfo.value = triggerInfo.value.copy(focusScaleFactor = scaleFactor)
             }
-        }.onGloballyPositioned {
-            updateTriggerBounds(it)
-        }.onFocusChanged {
-            val scaleFactor = if (it.isFocused) {
-                currentScaleFactor
-            } else {
-                0f
-            }
-            triggerInfo.value = triggerInfo.value.copy(focusScaleFactor = scaleFactor)
+        } else {
+            Modifier
         }
     }
 }

--- a/sdds-core/uikit/gradle.properties
+++ b/sdds-core/uikit/gradle.properties
@@ -2,5 +2,5 @@ nexus.artifactId=sdds-uikit
 nexus.snapshot=false
 nexus.description=SDDS UIKit library with base components for android view system
 versionMajor=0
-versionMinor=48
-versionPatch=1
+versionMinor=49
+versionPatch=0

--- a/tokens/plasma-stards-compose/gradle.properties
+++ b/tokens/plasma-stards-compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=plasma-star-ds-compose
 nexus.snapshot=false
 nexus.description=plasma-star-ds library for compose framework
 versionMajor=0
-versionMinor=37
-versionPatch=1
+versionMinor=38
+versionPatch=0
 
 theme-url=https://github.com/salute-developers/theme-converter/raw/main/themes/plasma_stards/0.7.0-alpha.zip
 components-version=0.19.0

--- a/tokens/plasma-stards-view/gradle.properties
+++ b/tokens/plasma-stards-view/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=plasma-star-ds
 nexus.snapshot=false
 nexus.description=plasma-star-ds library for view framework
 versionMajor=2
-versionMinor=39
-versionPatch=1
+versionMinor=40
+versionPatch=0
 
 summary.key=plasmaStarDS
 

--- a/tokens/plasma.giga.compose/gradle.properties
+++ b/tokens/plasma.giga.compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=plasma-giga-compose
 nexus.snapshot=false
 nexus.description=plasma-giga library for compose framework
 versionMajor=0
-versionMinor=35
-versionPatch=1
+versionMinor=36
+versionPatch=0
 
 theme-version=latest
 components-version=0.13.0

--- a/tokens/plasma.homeds.compose/gradle.properties
+++ b/tokens/plasma.homeds.compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=plasma-homeds-compose
 nexus.snapshot=false
 nexus.description=plasma-homeds library for compose framework
 versionMajor=0
-versionMinor=27
-versionPatch=1
+versionMinor=28
+versionPatch=0
 
 theme-version=0.4.0
 components-version=0.17.0

--- a/tokens/plasma.sd.service.compose/gradle.properties
+++ b/tokens/plasma.sd.service.compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=plasma-sd-service-compose
 nexus.snapshot=false
 nexus.description=plasma-sd-service library for compose framework
 versionMajor=0
-versionMinor=43
-versionPatch=1
+versionMinor=44
+versionPatch=0
 
 # ?????? plasma_b2c_ACTUAL_TYPOGRAPHY
 theme-version=0.2.0

--- a/tokens/plasma.sd.service.view/gradle.properties
+++ b/tokens/plasma.sd.service.view/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=plasma-sd-service
 nexus.snapshot=false
 nexus.description=plasma-sd-service theme library for view framework
 versionMajor=0
-versionMinor=38
-versionPatch=1
+versionMinor=39
+versionPatch=0
 
 theme-version=0.1.0
 components-version=0.15.0

--- a/tokens/sdds-finai-compose/gradle.properties
+++ b/tokens/sdds-finai-compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=sdds-finai-compose
 nexus.snapshot=false
 nexus.description=sdds finai library for compose framework
 versionMajor=0
-versionMinor=1
-versionPatch=1
+versionMinor=2
+versionPatch=0
 
 theme-version=0.7.1
 components-version=0.1.0

--- a/tokens/sdds-sbcom-compose/gradle.properties
+++ b/tokens/sdds-sbcom-compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=sdds-sbcom-compose
 nexus.snapshot=false
 nexus.description=sdds sbcom library for compose framework
 versionMajor=0
-versionMinor=12
-versionPatch=1
+versionMinor=13
+versionPatch=0
 
 components-version=0.9.0
 

--- a/tokens/sdds.serv.compose/gradle.properties
+++ b/tokens/sdds.serv.compose/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=sdds-serv-compose
 nexus.snapshot=false
 nexus.description=sdds-serv token library for compose framework
 versionMajor=0
-versionMinor=42
-versionPatch=1
+versionMinor=43
+versionPatch=0
 
 theme-version=0.9.0
 components-version=0.18.0

--- a/tokens/sdds.serv.view/gradle.properties
+++ b/tokens/sdds.serv.view/gradle.properties
@@ -2,8 +2,8 @@ nexus.artifactId=sdds-serv
 nexus.snapshot=false
 nexus.description=sdds-serv token library for view framework
 versionMajor=0
-versionMinor=42
-versionPatch=1
+versionMinor=43
+versionPatch=0
 
 theme-version=0.9.0
 components-version=0.18.0

--- a/tokens/summary.json
+++ b/tokens/summary.json
@@ -2,13 +2,13 @@
   "plasmaStarDS": {
     "viewSystem": {
       "title": "XML",
-      "version": "2.39.0",
+      "version": "2.40.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-star-ds/2.39.0/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-star-ds/2.40.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-star-ds/2.39.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-star-ds/2.40.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/xml/plasma-star-ds/changelog.json"
@@ -17,13 +17,13 @@
     },
     "composeUi": {
       "title": "Compose UI",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.37.0/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.38.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.37.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/0.38.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/compose/plasma-star-ds-compose/changelog.json"
@@ -34,13 +34,13 @@
   "plasmaGigaApp": {
     "viewSystem": {
       "title": "XML",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-giga-compose/0.35.0/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-giga-compose/0.36.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-giga-compose/0.35.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-giga-compose/0.36.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/xml/plasma-giga-compose/changelog.json"
@@ -49,13 +49,13 @@
     },
     "composeUi": {
       "title": "Compose UI",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.35.0/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.36.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.35.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/0.36.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/compose/plasma-giga-compose/changelog.json"
@@ -66,13 +66,13 @@
   "plasmaHomeDS": {
     "viewSystem": {
       "title": "XML",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-homeds-compose/0.27.0/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-homeds-compose/0.28.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-homeds-compose/0.27.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-homeds-compose/0.28.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/xml/plasma-homeds-compose/changelog.json"
@@ -81,13 +81,13 @@
     },
     "composeUi": {
       "title": "Compose UI",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.27.0/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.28.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.27.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/0.28.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/compose/plasma-homeds-compose/changelog.json"
@@ -98,13 +98,13 @@
   "plasmaSDService": {
     "viewSystem": {
       "title": "XML",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-sd-service/0.38.0/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-sd-service/0.39.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/xml/plasma-sd-service/0.38.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/xml/plasma-sd-service/0.39.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/xml/plasma-sd-service/changelog.json"
@@ -113,13 +113,13 @@
     },
     "composeUi": {
       "title": "Compose UI",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.43.0/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.44.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.43.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/0.44.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/compose/plasma-sd-service-compose/changelog.json"
@@ -127,16 +127,48 @@
       }
     }
   },
+  "sdds-finai": {
+    "viewSystem": {
+      "title": "XML",
+      "version": "0.2.0",
+      "links": {
+        "documentation": {
+          "href": "https://plasma.sberdevices.ru/xml/sdds-finai-compose/0.2.0/"
+        },
+        "changelog": {
+          "href": "https://plasma.sberdevices.ru/xml/sdds-finai-compose/0.2.0/CHANGELOG/"
+        },
+        "changelogData": {
+          "href": "https://plasma.sberdevices.ru/xml/sdds-finai-compose/changelog.json"
+        }
+      }
+    },
+    "composeUi": {
+      "title": "Compose UI",
+      "version": "0.2.0",
+      "links": {
+        "documentation": {
+          "href": "https://plasma.sberdevices.ru/compose/sdds-finai-compose/0.2.0/"
+        },
+        "changelog": {
+          "href": "https://plasma.sberdevices.ru/compose/sdds-finai-compose/0.2.0/CHANGELOG/"
+        },
+        "changelogData": {
+          "href": "https://plasma.sberdevices.ru/compose/sdds-finai-compose/changelog.json"
+        }
+      }
+    }
+  },
   "sdds-sbcom": {
     "viewSystem": {
       "title": "XML",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/xml/sdds-sbcom-compose/0.12.0/"
+          "href": "https://plasma.sberdevices.ru/xml/sdds-sbcom-compose/0.13.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/xml/sdds-sbcom-compose/0.12.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/xml/sdds-sbcom-compose/0.13.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/xml/sdds-sbcom-compose/changelog.json"
@@ -145,13 +177,13 @@
     },
     "composeUi": {
       "title": "Compose UI",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.12.0/"
+          "href": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.13.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.12.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/0.13.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/compose/sdds-sbcom-compose/changelog.json"
@@ -162,13 +194,13 @@
   "SDDSService": {
     "viewSystem": {
       "title": "XML",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/xml/sdds-serv/0.42.0/"
+          "href": "https://plasma.sberdevices.ru/xml/sdds-serv/0.43.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/xml/sdds-serv/0.42.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/xml/sdds-serv/0.43.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/xml/sdds-serv/changelog.json"
@@ -177,13 +209,13 @@
     },
     "composeUi": {
       "title": "Compose UI",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "links": {
         "documentation": {
-          "href": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.42.0/"
+          "href": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.43.0/"
         },
         "changelog": {
-          "href": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.42.0/CHANGELOG/"
+          "href": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/0.43.0/CHANGELOG/"
         },
         "changelogData": {
           "href": "https://plasma.sberdevices.ru/compose/sdds-serv-compose/changelog.json"


### PR DESCRIPTION
## sdds-uikit-compose

### Popover

- В модификаторе .popoverTrigger теперь есть возможность его отключения 

### What/why changed

В модификаторе popoverTrigger теперь есть возможность его отключения. При включенном модификаторе позиция триггера на layout постоянно отслеживается , что ведет к нагрузке на производительность в случае, когда триггеров много и они находятся в скроллящемся списке. С появлением этого параметра, отслеживание положения триггера начинается в момент вызова Popover (нажатие на триггер)

В подтверждение этому проведен эксперемент с замерами производительности

На первом снимке отображен момент скролла списка из 1000 Buttons помещенных в LazyColumn, к которым не применен модификатор .popoverTrigger. Видно некоторое количество кадров, время отрисовки которых превысило ожидаемое (эти кадры называются Junky Frames). В более подробном отчете, в Choreographer#doFrame видно, что за время скролла, параметр traversal (в него входят measure, layout ,draw ) занимает 5,56% от всего времени подготовки кадров.
 
<img width="1562" height="533" alt="only 1000 Buttons" src="https://github.com/user-attachments/assets/b69ee3a3-7aca-4ea2-b0b4-650fbb011032" />

Второй снимок иллюстрирует ситуацию, когда к этим же 1000 Buttons применен модификатор .popoverTrigger, у которого параметр enabled включен всегда, то есть положение каждого триггера на экране отслеживается постоянно. Видно, что количество Junky frames заметно прибавилось , а traversal составляет теперь 10,66% , что в два раза больше, чем в прошлом эксперементе.

<img width="1562" height="815" alt="1000 buttons not optimized" src="https://github.com/user-attachments/assets/f37144da-45ea-4f1e-b1a8-906edf2442af" />

И, наконец, третий снимок - к этим же 1000 Buttons применен модификатор .popoverTrigger, у которого параметр enabled включается только в момент нажатия на триггер. Отстутствуют Junky Frames, traversal составляет 5,2% за время пока идет анимация скролла. 

<img width="1561" height="678" alt="1000 buttons optimized" src="https://github.com/user-attachments/assets/88b06a02-3a78-461a-84dd-d687d062cac0" />

Наличие Junky Frames в первом эксперементе может быть обусловлено более резким движением для скролла списка. Более низкий процент занимаемый traversal в 3 экспеоементе, по сравнению с 1, объясняется чуть меньшим временем анимации самого скролла.